### PR TITLE
Add project-scoped expandable terminal panel

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -220,7 +220,7 @@ If changing ordering, row height, popup padding, or selected-item behavior, upda
 
 ## Session and Context-Menu Behavior
 
-- Project terminal processes are keyed by canonical project work directory, not by session ID. Switching sessions in one project must retain the same shell process and output; switching projects selects that project's independent terminal.
+- Project terminal groups are keyed by canonical project work directory, not by session ID. Each project can own multiple independent shell tabs; switching sessions in one project must retain its shells, active tab, and output, while switching projects selects that project's terminal group.
 
 - The project attach button appears while hovering the `PROJECTS` header. It is the only sidebar action synchronized from `App::sync_sidebar_action_visibility` and the retained app-level pointer.
 - `ProjectHeader` locally owns project-row hover hit-testing, action-button paint/redraw, and typed select/new/detach actions for both fixed and portal-list headers. Keep its controls laid out inside the fixed-width action slot; do not restore app-level project-row geometry synchronization.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -220,6 +220,8 @@ If changing ordering, row height, popup padding, or selected-item behavior, upda
 
 ## Session and Context-Menu Behavior
 
+- Project terminal processes are keyed by canonical project work directory, not by session ID. Switching sessions in one project must retain the same shell process and output; switching projects selects that project's independent terminal.
+
 - The project attach button appears while hovering the `PROJECTS` header. It is the only sidebar action synchronized from `App::sync_sidebar_action_visibility` and the retained app-level pointer.
 - `ProjectHeader` locally owns project-row hover hit-testing, action-button paint/redraw, and typed select/new/detach actions for both fixed and portal-list headers. Keep its controls laid out inside the fixed-width action slot; do not restore app-level project-row geometry synchronization.
 - Compute `ProjectHeader` hover from `MouseMove` against the header's clipped rectangle. Parent `FingerHoverOut` can fire when the pointer enters a nested button, which must not hide the action group.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1565,6 +1565,14 @@ dependencies = [
 ]
 
 [[package]]
+name = "makepad-terminal-core"
+version = "1.0.0"
+source = "git+https://github.com/makepad/makepad.git?branch=dev#b41e7404b6bb893d32f7d2924cd7b1c28983547f"
+dependencies = [
+ "windows 0.62.2",
+]
+
+[[package]]
 name = "makepad-tsdf"
 version = "0.1.0"
 source = "git+https://github.com/makepad/makepad.git?branch=dev#b41e7404b6bb893d32f7d2924cd7b1c28983547f"
@@ -3029,6 +3037,7 @@ dependencies = [
  "base64",
  "cargo-packager-updater",
  "directories",
+ "makepad-terminal-core",
  "makepad-widgets",
  "png",
  "rfd",

--- a/crates/threadlane/Cargo.toml
+++ b/crates/threadlane/Cargo.toml
@@ -6,6 +6,7 @@ description = "GPU Desktop UI application for threadlane agent using Makepad"
 
 [dependencies]
 makepad-widgets = { git = "https://github.com/makepad/makepad.git", branch = "dev" }
+makepad-terminal-core = { git = "https://github.com/makepad/makepad.git", branch = "dev" }
 unicode-segmentation = "1.12.0"
 threadlane-agent = { path = "../threadlane-agent" }
 threadlane-coding-agent = { path = "../threadlane-coding-agent" }

--- a/crates/threadlane/src/app/mod.rs
+++ b/crates/threadlane/src/app/mod.rs
@@ -38,7 +38,7 @@ use threadlane_coding_agent::{
 use threadlane_provider::auth;
 use threadlane_provider::openai::{fetch_available_models, OpenAIClient};
 
-use makepad_terminal_core::{Pty, Terminal};
+use makepad_terminal_core::{Pty, TermKeyCode as TerminalKeyCode, Terminal};
 use std::collections::HashMap;
 use std::path::{Path, PathBuf};
 use std::sync::mpsc::{channel, Receiver, Sender};
@@ -49,10 +49,27 @@ struct ProjectTerminalSession {
     emulator: Terminal,
 }
 
+impl ProjectTerminalSession {
+    fn terminate(self) {
+        let Self { pty, emulator } = self;
+        drop(pty);
+        drop(emulator);
+    }
+}
+
 #[derive(Default)]
 struct ProjectTerminalGroup {
     sessions: Vec<ProjectTerminalSession>,
     active: usize,
+    error: Option<String>,
+}
+
+impl ProjectTerminalGroup {
+    fn terminate(self) {
+        for session in self.sessions {
+            session.terminate();
+        }
+    }
 }
 
 const ANTIGRAVITY_MODELS: &[&str] = &[
@@ -169,6 +186,10 @@ fn project_name(path: &Path) -> String {
         .map(|name| name.to_string_lossy().into_owned())
         .filter(|name| !name.is_empty())
         .unwrap_or_else(|| path.display().to_string())
+}
+
+fn canonical_terminal_work_dir(work_dir: &Path) -> PathBuf {
+    std::fs::canonicalize(work_dir).unwrap_or_else(|_| work_dir.to_path_buf())
 }
 
 use crate::path_utils::compact_workspace_path;
@@ -2785,8 +2806,6 @@ pub struct App {
     #[rust]
     project_terminals: HashMap<PathBuf, ProjectTerminalGroup>,
     #[rust]
-    next_terminal_id: u64,
-    #[rust]
     terminal_poll_next_frame: NextFrame,
 }
 
@@ -2794,8 +2813,7 @@ impl ScriptHook for App {}
 
 impl MatchEvent for App {
     fn handle_startup(&mut self, cx: &mut Cx) {
-        self.next_terminal_id = 1;
-        self.terminal_poll_next_frame = cx.new_next_frame();
+        self.terminal_poll_next_frame = NextFrame::default();
         let (tx, rx) = channel::<GuiAgentEvent>();
         self.tx = Some(tx);
         self.rx = Some(Arc::new(Mutex::new(rx)));
@@ -3038,8 +3056,24 @@ impl MatchEvent for App {
                 crate::components::terminal_panel::ProjectTerminalAction::Input(bytes) => {
                     self.write_terminal_bytes(cx, bytes);
                 }
-                crate::components::terminal_panel::ProjectTerminalAction::LayoutChanged => {
-                    cx.redraw_all();
+                crate::components::terminal_panel::ProjectTerminalAction::Key {
+                    key,
+                    shift,
+                    control,
+                    alt,
+                } => self.write_terminal_key(cx, key, shift, control, alt),
+                crate::components::terminal_panel::ProjectTerminalAction::LayoutChanged {
+                    cols,
+                    rows,
+                } => {
+                    if self
+                        .active_terminal_project()
+                        .and_then(|work_dir| self.project_terminals.get(&work_dir))
+                        .is_none_or(|group| group.sessions.is_empty())
+                    {
+                        self.create_project_terminal(cx);
+                    }
+                    self.resize_project_terminals(cx, cols, rows);
                 }
                 crate::components::terminal_panel::ProjectTerminalAction::New => {
                     self.create_project_terminal(cx);
@@ -3465,7 +3499,9 @@ impl AppMain for App {
         self.poll_update_status(cx);
         if self.terminal_poll_next_frame.is_event(event).is_some() {
             self.poll_terminal_output(cx);
-            self.terminal_poll_next_frame = cx.new_next_frame();
+            if self.has_live_terminal_sessions() {
+                self.terminal_poll_next_frame = cx.new_next_frame();
+            }
         }
         {
             let mut scope = Scope::with_data(&mut self.workspace_state);
@@ -4246,6 +4282,12 @@ impl App {
                 let was_active = self.active_work_dir() == Some(work_dir.as_path());
                 self.session_runtimes
                     .retain(|key, _| key.work_dir != work_dir);
+                if let Some(group) = self
+                    .project_terminals
+                    .remove(&canonical_terminal_work_dir(&work_dir))
+                {
+                    group.terminate();
+                }
                 let keys = self
                     .workspace_state
                     .keys_for_project(&work_dir)
@@ -4289,7 +4331,7 @@ impl App {
     fn active_terminal_project(&self) -> Option<PathBuf> {
         self.workspace_state
             .active_key()
-            .map(|key| key.work_dir.clone())
+            .map(|key| canonical_terminal_work_dir(&key.work_dir))
     }
 
     fn sync_terminal_project(&mut self, cx: &mut Cx) {
@@ -4298,11 +4340,6 @@ impl App {
         };
         let project = project_name(&work_dir);
         let terminal = self.ui.project_terminal(cx, ids!(project_terminal));
-        terminal.set_project(cx, &project);
-        if !self.project_terminals.contains_key(&work_dir) {
-            self.create_project_terminal(cx);
-            return;
-        }
         if let Some(group) = self.project_terminals.get(&work_dir) {
             let names = group
                 .sessions
@@ -4316,24 +4353,26 @@ impl App {
                     }
                 })
                 .collect::<Vec<_>>();
-            let output = group
-                .sessions
-                .get(group.active)
-                .map(Self::terminal_text)
+            let output = group.sessions.get(group.active).map(Self::terminal_text);
+            let output = output
+                .as_deref()
+                .or(group.error.as_deref())
                 .unwrap_or_default();
-            let output = output.as_str();
             terminal.set_terminals(cx, &names, Some(group.active), output);
+        } else {
+            terminal.set_terminals(cx, &[], None, "");
         }
     }
 
     fn spawn_project_terminal(
         &mut self,
         work_dir: &Path,
+        cols: u16,
+        rows: u16,
     ) -> Result<ProjectTerminalSession, String> {
-        self.next_terminal_id += 1;
         let pty = Pty::spawn(
-            80,
-            24,
+            cols,
+            rows,
             None,
             &[("TERM", "xterm-256color")],
             Some(work_dir),
@@ -4341,32 +4380,40 @@ impl App {
         .map_err(|error| format!("Could not start terminal: {error}"))?;
         Ok(ProjectTerminalSession {
             pty,
-            emulator: Terminal::new(80, 24),
+            emulator: Terminal::new(cols as usize, rows as usize),
         })
     }
 
     fn create_project_terminal(&mut self, cx: &mut Cx) {
-        const MAX_PROJECT_TERMINALS: usize = 6;
         let Some(work_dir) = self.active_terminal_project() else {
             return;
         };
         if self
             .project_terminals
             .get(&work_dir)
-            .is_some_and(|group| group.sessions.len() >= MAX_PROJECT_TERMINALS)
+            .is_some_and(|group| {
+                group.sessions.len()
+                    >= crate::components::terminal_panel::MAX_VISIBLE_TERMINALS
+            })
         {
             return;
         }
-        match self.spawn_project_terminal(&work_dir) {
+        let (cols, rows) = self
+            .ui
+            .project_terminal(cx, ids!(project_terminal))
+            .dimensions(cx)
+            .unwrap_or((80, 24));
+        match self.spawn_project_terminal(&work_dir, cols as u16, rows as u16) {
             Ok(session) => {
                 let group = self.project_terminals.entry(work_dir).or_default();
                 group.sessions.push(session);
                 group.active = group.sessions.len() - 1;
+                group.error = None;
+                self.terminal_poll_next_frame = cx.new_next_frame();
             }
             Err(error) => {
-                self.ui
-                    .project_terminal(cx, ids!(project_terminal))
-                    .set_terminals(cx, &[], None, &format!("{error}\n"));
+                self.project_terminals.entry(work_dir).or_default().error = Some(error);
+                self.sync_terminal_project(cx);
                 return;
             }
         }
@@ -4385,6 +4432,29 @@ impl App {
         self.sync_terminal_project(cx);
     }
 
+    fn resize_project_terminals(&mut self, cx: &mut Cx, cols: usize, rows: usize) {
+        let Some(work_dir) = self.active_terminal_project() else {
+            return;
+        };
+        let cols = cols.clamp(1, u16::MAX as usize);
+        let rows = rows.clamp(1, u16::MAX as usize);
+        if let Some(group) = self.project_terminals.get_mut(&work_dir) {
+            for session in &mut group.sessions {
+                if session.emulator.screen().cols() == cols
+                    && session.emulator.screen().rows() == rows
+                {
+                    continue;
+                }
+                if let Err(error) = session.pty.resize(cols as u16, rows as u16) {
+                    eprintln!("Terminal resize failed: {error}");
+                    continue;
+                }
+                session.emulator.resize(cols, rows);
+            }
+        }
+        self.sync_terminal_project(cx);
+    }
+
     fn close_project_terminal(&mut self, cx: &mut Cx, index: usize) {
         let Some(work_dir) = self.active_terminal_project() else {
             return;
@@ -4393,7 +4463,7 @@ impl App {
             if index >= group.sessions.len() {
                 return;
             }
-            group.sessions.remove(index);
+            group.sessions.remove(index).terminate();
             if group.sessions.is_empty() {
                 true
             } else {
@@ -4408,7 +4478,9 @@ impl App {
             return;
         };
         if remove_group {
-            self.project_terminals.remove(&work_dir);
+            if let Some(group) = self.project_terminals.remove(&work_dir) {
+                group.terminate();
+            }
         }
         self.sync_terminal_project(cx);
     }
@@ -4417,7 +4489,11 @@ impl App {
         let Some(work_dir) = self.active_terminal_project() else {
             return;
         };
-        if !self.project_terminals.contains_key(&work_dir) {
+        if self
+            .project_terminals
+            .get(&work_dir)
+            .is_none_or(|group| group.sessions.is_empty())
+        {
             self.create_project_terminal(cx);
         }
         let Some(group) = self.project_terminals.get_mut(&work_dir) else {
@@ -4432,10 +4508,49 @@ impl App {
         self.sync_terminal_project(cx);
     }
 
+    fn write_terminal_key(
+        &mut self,
+        cx: &mut Cx,
+        key: TerminalKeyCode,
+        shift: bool,
+        control: bool,
+        alt: bool,
+    ) {
+        let Some(work_dir) = self.active_terminal_project() else {
+            return;
+        };
+        if self
+            .project_terminals
+            .get(&work_dir)
+            .is_none_or(|group| group.sessions.is_empty())
+        {
+            self.create_project_terminal(cx);
+        }
+        let Some(terminal) = self
+            .project_terminals
+            .get_mut(&work_dir)
+            .and_then(|group| group.sessions.get_mut(group.active))
+        else {
+            return;
+        };
+        if let Some(bytes) = terminal.emulator.encode_key(key, "", shift, control, alt) {
+            if let Err(error) = terminal.pty.write(&bytes) {
+                eprintln!("Terminal write failed: {error}");
+            }
+        }
+        self.sync_terminal_project(cx);
+    }
+
     fn poll_terminal_output(&mut self, cx: &mut Cx) {
+        const MAX_PTY_READS_PER_FRAME: usize = 8;
+        let mut processed_output = false;
         for group in self.project_terminals.values_mut() {
             for session in &mut group.sessions {
-                while let Some(bytes) = session.pty.try_read() {
+                for _ in 0..MAX_PTY_READS_PER_FRAME {
+                    let Some(bytes) = session.pty.try_read() else {
+                        break;
+                    };
+                    processed_output = true;
                     session.emulator.process_bytes(&bytes);
                     let outbound = session.emulator.take_outbound();
                     if !outbound.is_empty() {
@@ -4444,7 +4559,15 @@ impl App {
                 }
             }
         }
-        self.sync_terminal_project(cx);
+        if processed_output {
+            self.sync_terminal_project(cx);
+        }
+    }
+
+    fn has_live_terminal_sessions(&self) -> bool {
+        self.project_terminals
+            .values()
+            .any(|group| !group.sessions.is_empty())
     }
 
     fn terminal_text(session: &ProjectTerminalSession) -> String {
@@ -4476,11 +4599,14 @@ impl App {
             push_row(row, cells);
         }
         for row in 0..screen.rows() {
-            push_row(cursor_row - screen.cursor.y + row, screen.grid.row_slice(row));
+            push_row(screen.scrollback().len() + row, screen.grid.row_slice(row));
         }
         const MAX_TERMINAL_OUTPUT: usize = 256 * 1024;
         if output.len() > MAX_TERMINAL_OUTPUT {
-            let cutoff = output.len() - MAX_TERMINAL_OUTPUT;
+            let mut cutoff = output.len() - MAX_TERMINAL_OUTPUT;
+            while cutoff < output.len() && !output.is_char_boundary(cutoff) {
+                cutoff += 1;
+            }
             let cutoff = output[cutoff..]
                 .char_indices()
                 .find_map(|(offset, ch)| (ch == '\n').then_some(cutoff + offset + 1))

--- a/crates/threadlane/src/app/mod.rs
+++ b/crates/threadlane/src/app/mod.rs
@@ -38,30 +38,21 @@ use threadlane_coding_agent::{
 use threadlane_provider::auth;
 use threadlane_provider::openai::{fetch_available_models, OpenAIClient};
 
+use makepad_terminal_core::{Pty, Terminal};
 use std::collections::HashMap;
-use std::io::{BufReader, Read, Write};
 use std::path::{Path, PathBuf};
-use std::process::{Child, ChildStdin, Command, Stdio};
 use std::sync::mpsc::{channel, Receiver, Sender};
 use std::sync::{Arc, Mutex};
 
 struct ProjectTerminalSession {
-    id: u64,
-    child: Child,
-    stdin: ChildStdin,
-    output: String,
+    pty: Pty,
+    emulator: Terminal,
 }
 
 #[derive(Default)]
 struct ProjectTerminalGroup {
     sessions: Vec<ProjectTerminalSession>,
     active: usize,
-}
-
-struct ProjectTerminalOutput {
-    work_dir: PathBuf,
-    terminal_id: u64,
-    bytes: Vec<u8>,
 }
 
 const ANTIGRAVITY_MODELS: &[&str] = &[
@@ -1974,6 +1965,13 @@ script_mod! {
                                 }
                             }
 
+                            terminal_header_btn := mod.components.TerminalIconButton {
+                                width: 24
+                                height: 24
+                                icon_walk: Walk{width: 11 height: 11}
+                                draw_icon +: { svg: crate_resource("self:resources/icons/terminal.svg") }
+                            }
+
                             caps_btn := Button {
                                 width: Fit
                                 height: 28
@@ -2779,9 +2777,7 @@ pub struct App {
     #[rust]
     next_terminal_id: u64,
     #[rust]
-    terminal_tx: Option<Sender<ProjectTerminalOutput>>,
-    #[rust]
-    terminal_rx: Option<Receiver<ProjectTerminalOutput>>,
+    terminal_poll_next_frame: NextFrame,
 }
 
 impl ScriptHook for App {}
@@ -2789,9 +2785,7 @@ impl ScriptHook for App {}
 impl MatchEvent for App {
     fn handle_startup(&mut self, cx: &mut Cx) {
         self.next_terminal_id = 1;
-        let (terminal_tx, terminal_rx) = channel();
-        self.terminal_tx = Some(terminal_tx);
-        self.terminal_rx = Some(terminal_rx);
+        self.terminal_poll_next_frame = cx.new_next_frame();
         let (tx, rx) = channel::<GuiAgentEvent>();
         self.tx = Some(tx);
         self.rx = Some(Arc::new(Mutex::new(rx)));
@@ -3031,8 +3025,11 @@ impl MatchEvent for App {
             .actions(actions);
         for action in terminal_actions {
             match action {
-                crate::components::terminal_panel::ProjectTerminalAction::Run(command) => {
-                    self.run_terminal_command(cx, command);
+                crate::components::terminal_panel::ProjectTerminalAction::Input(bytes) => {
+                    self.write_terminal_bytes(cx, bytes);
+                }
+                crate::components::terminal_panel::ProjectTerminalAction::LayoutChanged => {
+                    cx.redraw_all();
                 }
                 crate::components::terminal_panel::ProjectTerminalAction::New => {
                     self.create_project_terminal(cx);
@@ -3052,6 +3049,12 @@ impl MatchEvent for App {
             {
                 self.apply_image_picker_result(cx, key.clone(), attachment.clone());
             }
+        }
+
+        if self.ui.button(cx, ids!(terminal_header_btn)).clicked(actions) {
+            self.ui
+                .project_terminal(cx, ids!(project_terminal))
+                .toggle(cx);
         }
 
         if self.ui.button(cx, ids!(settings_btn)).clicked(actions) {
@@ -3450,7 +3453,10 @@ impl AppMain for App {
         self.match_event(cx, event);
         self.poll_agent_events(cx);
         self.poll_update_status(cx);
-        self.poll_terminal_output(cx);
+        if self.terminal_poll_next_frame.is_event(event).is_some() {
+            self.poll_terminal_output(cx);
+            self.terminal_poll_next_frame = cx.new_next_frame();
+        }
         {
             let mut scope = Scope::with_data(&mut self.workspace_state);
             self.ui.handle_event(cx, event, &mut scope);
@@ -4283,6 +4289,10 @@ impl App {
         let project = project_name(&work_dir);
         let terminal = self.ui.project_terminal(cx, ids!(project_terminal));
         terminal.set_project(cx, &project);
+        if !self.project_terminals.contains_key(&work_dir) {
+            self.create_project_terminal(cx);
+            return;
+        }
         if let Some(group) = self.project_terminals.get(&work_dir) {
             let names = group
                 .sessions
@@ -4299,16 +4309,10 @@ impl App {
             let output = group
                 .sessions
                 .get(group.active)
-                .map(|session| session.output.as_str())
+                .map(Self::terminal_text)
                 .unwrap_or_default();
+            let output = output.as_str();
             terminal.set_terminals(cx, &names, Some(group.active), output);
-        } else {
-            terminal.set_terminals(
-                cx,
-                &[],
-                None,
-                "Use + to open a terminal for this project.\n",
-            );
         }
     }
 
@@ -4316,60 +4320,18 @@ impl App {
         &mut self,
         work_dir: &Path,
     ) -> Result<ProjectTerminalSession, String> {
-        let mut command = if cfg!(windows) {
-            Command::new("cmd.exe")
-        } else {
-            let shell = std::env::var_os("SHELL").unwrap_or_else(|| "/bin/sh".into());
-            Command::new(shell)
-        };
-        let mut child = command
-            .current_dir(work_dir)
-            .stdin(Stdio::piped())
-            .stdout(Stdio::piped())
-            .stderr(Stdio::piped())
-            .spawn()
-            .map_err(|error| format!("Could not start terminal: {error}"))?;
-        let stdin = child.stdin.take().ok_or("Terminal stdin was unavailable")?;
-        let stdout = child
-            .stdout
-            .take()
-            .ok_or("Terminal stdout was unavailable")?;
-        let stderr = child
-            .stderr
-            .take()
-            .ok_or("Terminal stderr was unavailable")?;
-        let tx = self
-            .terminal_tx
-            .clone()
-            .ok_or("Terminal channel was unavailable")?;
-        let terminal_id = self.next_terminal_id;
         self.next_terminal_id += 1;
-        for reader in [Box::new(stdout) as Box<dyn Read + Send>, Box::new(stderr)] {
-            let tx = tx.clone();
-            let work_dir = work_dir.to_path_buf();
-            std::thread::spawn(move || {
-                let mut reader = BufReader::new(reader);
-                let mut buffer = [0_u8; 4096];
-                loop {
-                    match reader.read(&mut buffer) {
-                        Ok(0) | Err(_) => break,
-                        Ok(count) => {
-                            let _ = tx.send(ProjectTerminalOutput {
-                                work_dir: work_dir.clone(),
-                                terminal_id,
-                                bytes: buffer[..count].to_vec(),
-                            });
-                            SignalToUI::set_ui_signal();
-                        }
-                    }
-                }
-            });
-        }
+        let pty = Pty::spawn(
+            80,
+            24,
+            None,
+            &[("TERM", "xterm-256color")],
+            Some(work_dir),
+        )
+        .map_err(|error| format!("Could not start terminal: {error}"))?;
         Ok(ProjectTerminalSession {
-            id: terminal_id,
-            child,
-            stdin,
-            output: String::new(),
+            pty,
+            emulator: Terminal::new(80, 24),
         })
     }
 
@@ -4421,9 +4383,7 @@ impl App {
             if index >= group.sessions.len() {
                 return;
             }
-            let mut session = group.sessions.remove(index);
-            let _ = session.child.kill();
-            let _ = session.child.wait();
+            group.sessions.remove(index);
             if group.sessions.is_empty() {
                 true
             } else {
@@ -4443,7 +4403,7 @@ impl App {
         self.sync_terminal_project(cx);
     }
 
-    fn run_terminal_command(&mut self, cx: &mut Cx, command: String) {
+    fn write_terminal_bytes(&mut self, cx: &mut Cx, bytes: Vec<u8>) {
         let Some(work_dir) = self.active_terminal_project() else {
             return;
         };
@@ -4456,56 +4416,69 @@ impl App {
         let Some(terminal) = group.sessions.get_mut(group.active) else {
             return;
         };
-        terminal.output.push_str(&format!("$ {command}\n"));
-        let mut bytes = command.into_bytes();
-        bytes.push(b'\n');
-        if let Err(error) = terminal
-            .stdin
-            .write_all(&bytes)
-            .and_then(|_| terminal.stdin.flush())
-        {
-            terminal
-                .output
-                .push_str(&format!("Terminal write failed: {error}\n"));
+        if let Err(error) = terminal.pty.write(&bytes) {
+            eprintln!("Terminal write failed: {error}");
         }
         self.sync_terminal_project(cx);
     }
 
     fn poll_terminal_output(&mut self, cx: &mut Cx) {
-        let Some(rx) = self.terminal_rx.as_ref() else {
-            return;
-        };
-        let events: Vec<_> = rx.try_iter().collect();
-        if events.is_empty() {
-            return;
-        }
-        for event in events {
-            let Some(terminal) =
-                self.project_terminals
-                    .get_mut(&event.work_dir)
-                    .and_then(|group| {
-                        group
-                            .sessions
-                            .iter_mut()
-                            .find(|session| session.id == event.terminal_id)
-                    })
-            else {
-                continue;
-            };
-            terminal
-                .output
-                .push_str(&String::from_utf8_lossy(&event.bytes));
-            const MAX_TERMINAL_OUTPUT: usize = 256 * 1024;
-            if terminal.output.len() > MAX_TERMINAL_OUTPUT {
-                let cutoff = terminal.output.len() - MAX_TERMINAL_OUTPUT;
-                let cutoff = terminal.output[cutoff..]
-                    .char_indices()
-                    .find_map(|(offset, ch)| (ch == '\n').then_some(cutoff + offset + 1))
-                    .unwrap_or(cutoff);
-                terminal.output.drain(..cutoff);
+        for group in self.project_terminals.values_mut() {
+            for session in &mut group.sessions {
+                while let Some(bytes) = session.pty.try_read() {
+                    session.emulator.process_bytes(&bytes);
+                    let outbound = session.emulator.take_outbound();
+                    if !outbound.is_empty() {
+                        let _ = session.pty.write(&outbound);
+                    }
+                }
             }
         }
         self.sync_terminal_project(cx);
+    }
+
+    fn terminal_text(session: &ProjectTerminalSession) -> String {
+        let screen = session.emulator.screen();
+        const CURSOR_MARKER: char = '\u{e000}';
+        let cursor_row = screen.scrollback().len() + screen.cursor.y;
+        let cursor_col = screen.cursor.x;
+        let mut output = String::new();
+        let mut push_row = |row_index: usize, cells: &[makepad_terminal_core::Cell]| {
+            let mut line: String = cells.iter().map(|cell| cell.codepoint).collect();
+            if row_index == cursor_row {
+                let width = line.chars().count();
+                if width < cursor_col {
+                    line.extend(std::iter::repeat(' ').take(cursor_col - width));
+                }
+                let byte_index = line
+                    .char_indices()
+                    .nth(cursor_col)
+                    .map(|(index, _)| index)
+                    .unwrap_or(line.len());
+                line.insert(byte_index, CURSOR_MARKER);
+            } else {
+                line = line.trim_end().to_owned();
+            }
+            output.push_str(&line);
+            output.push('\n');
+        };
+        for (row, cells) in screen.scrollback().iter().enumerate() {
+            push_row(row, cells);
+        }
+        for row in 0..screen.rows() {
+            push_row(cursor_row - screen.cursor.y + row, screen.grid.row_slice(row));
+        }
+        const MAX_TERMINAL_OUTPUT: usize = 256 * 1024;
+        if output.len() > MAX_TERMINAL_OUTPUT {
+            let cutoff = output.len() - MAX_TERMINAL_OUTPUT;
+            let cutoff = output[cutoff..]
+                .char_indices()
+                .find_map(|(offset, ch)| (ch == '\n').then_some(cutoff + offset + 1))
+                .unwrap_or(cutoff);
+            output.drain(..cutoff);
+        }
+        output.pop();
+        output
     }
 
     fn select_workspace(&mut self, work_dir: PathBuf, session_id: impl Into<String>) {

--- a/crates/threadlane/src/app/mod.rs
+++ b/crates/threadlane/src/app/mod.rs
@@ -1750,13 +1750,13 @@ script_mod! {
                         splitter: Splitter {
                             size: 6.0
                             draw_bg +: {
-                                color: uniform(#x242930)
-                                color_hover: uniform(#x3a4452)
+                                color: uniform(#x303946)
+                                color_hover: uniform(#x4b5d70)
                                 color_drag: uniform(#x6a7b91)
 
                                 pixel: fn() {
                                     let sdf = Sdf2d.viewport(self.pos * self.rect_size)
-                                    sdf.clear(#x181a1f)
+                                    sdf.clear(#x00000000)
                                     let line_color = mix(
                                         self.color
                                         mix(self.color_hover, self.color_drag, self.drag)
@@ -1812,6 +1812,16 @@ script_mod! {
                             flow: Down
                             spacing: 0
                             padding: Inset{left: 8 top: 8 right: 8 bottom: 10}
+                            show_bg: true
+                            draw_bg +: {
+                                color: #x2d3744
+                                pixel: fn() {
+                                    let sdf = Sdf2d.viewport(self.pos * self.rect_size)
+                                    sdf.clear(#x00000000)
+                                    sdf.rect(self.rect_size.x - 1.0, 0.0, 1.0, self.rect_size.y)
+                                    return sdf.fill(self.color)
+                                }
+                            }
 
                             sidebar_brand := View {
                                 width: Fill

--- a/crates/threadlane/src/app/mod.rs
+++ b/crates/threadlane/src/app/mod.rs
@@ -4,6 +4,7 @@
 
 use crate::components::model_dropdown::IconDropDownWidgetRefExt;
 use crate::components::session_row::ProjectHeaderAction;
+use crate::components::terminal_panel::ProjectTerminalWidgetRefExt;
 use crate::panels::chat::{
     accepts_generation_event, concise_status, draft_for_cancellation, submitted_draft, ChatList,
     ChatListWidgetRefExt, ComposerState, ComposerStatus, GenerationEvent, StarterPromptAction,
@@ -38,9 +39,22 @@ use threadlane_provider::auth;
 use threadlane_provider::openai::{fetch_available_models, OpenAIClient};
 
 use std::collections::HashMap;
+use std::io::{BufReader, Read, Write};
 use std::path::{Path, PathBuf};
+use std::process::{Child, ChildStdin, Command, Stdio};
 use std::sync::mpsc::{channel, Receiver, Sender};
 use std::sync::{Arc, Mutex};
+
+struct ProjectTerminalSession {
+    _child: Child,
+    stdin: ChildStdin,
+    output: String,
+}
+
+struct ProjectTerminalOutput {
+    work_dir: PathBuf,
+    bytes: Vec<u8>,
+}
 
 const ANTIGRAVITY_MODELS: &[&str] = &[
     "antigravity/gemini-3.6-flash",
@@ -2061,6 +2075,8 @@ script_mod! {
                                     }
                                 }
                             }
+
+                            project_terminal := mod.components.ProjectTerminal {}
                             }
 
 
@@ -2411,12 +2427,21 @@ pub struct App {
     update_rx: Option<Arc<Mutex<Receiver<UpdateStatus>>>>,
     #[rust]
     starter_prompt_focus_pending: bool,
+    #[rust]
+    project_terminals: HashMap<PathBuf, ProjectTerminalSession>,
+    #[rust]
+    terminal_tx: Option<Sender<ProjectTerminalOutput>>,
+    #[rust]
+    terminal_rx: Option<Receiver<ProjectTerminalOutput>>,
 }
 
 impl ScriptHook for App {}
 
 impl MatchEvent for App {
     fn handle_startup(&mut self, cx: &mut Cx) {
+        let (terminal_tx, terminal_rx) = channel();
+        self.terminal_tx = Some(terminal_tx);
+        self.terminal_rx = Some(terminal_rx);
         let (tx, rx) = channel::<GuiAgentEvent>();
         self.tx = Some(tx);
         self.rx = Some(Arc::new(Mutex::new(rx)));
@@ -2649,6 +2674,13 @@ impl MatchEvent for App {
     }
 
     fn handle_actions(&mut self, cx: &mut Cx, actions: &Actions) {
+        if let Some(command) = self
+            .ui
+            .project_terminal(cx, ids!(project_terminal))
+            .command(actions)
+        {
+            self.run_terminal_command(cx, command);
+        }
         for action in actions {
             if let Some(ImagePickerAction::Loaded { key, attachment }) =
                 action.downcast_ref::<ImagePickerAction>()
@@ -3053,6 +3085,7 @@ impl AppMain for App {
         self.match_event(cx, event);
         self.poll_agent_events(cx);
         self.poll_update_status(cx);
+        self.poll_terminal_output(cx);
         {
             let mut scope = Scope::with_data(&mut self.workspace_state);
             self.ui.handle_event(cx, event, &mut scope);
@@ -3872,6 +3905,139 @@ impl App {
         (api_key, account_id)
     }
 
+    fn sync_terminal_project(&mut self, cx: &mut Cx) {
+        let Some(key) = self.workspace_state.active_key() else {
+            return;
+        };
+        let project = project_name(&key.work_dir);
+        let output = self
+            .project_terminals
+            .get(&key.work_dir)
+            .map(|terminal| terminal.output.as_str())
+            .unwrap_or("Terminal ready. Run a command to start the project shell.\n");
+        let terminal = self.ui.project_terminal(cx, ids!(project_terminal));
+        terminal.set_project(cx, &project);
+        terminal.set_output(cx, output);
+    }
+
+    fn start_project_terminal(&mut self, work_dir: &Path) -> Result<(), String> {
+        if self.project_terminals.contains_key(work_dir) {
+            return Ok(());
+        }
+        let mut command = if cfg!(windows) {
+            Command::new("cmd.exe")
+        } else {
+            let shell = std::env::var_os("SHELL").unwrap_or_else(|| "/bin/sh".into());
+            Command::new(shell)
+        };
+        let mut child = command
+            .current_dir(work_dir)
+            .stdin(Stdio::piped())
+            .stdout(Stdio::piped())
+            .stderr(Stdio::piped())
+            .spawn()
+            .map_err(|error| format!("Could not start terminal: {error}"))?;
+        let stdin = child.stdin.take().ok_or("Terminal stdin was unavailable")?;
+        let stdout = child
+            .stdout
+            .take()
+            .ok_or("Terminal stdout was unavailable")?;
+        let stderr = child
+            .stderr
+            .take()
+            .ok_or("Terminal stderr was unavailable")?;
+        let tx = self
+            .terminal_tx
+            .clone()
+            .ok_or("Terminal channel was unavailable")?;
+        for reader in [Box::new(stdout) as Box<dyn Read + Send>, Box::new(stderr)] {
+            let tx = tx.clone();
+            let work_dir = work_dir.to_path_buf();
+            std::thread::spawn(move || {
+                let mut reader = BufReader::new(reader);
+                let mut buffer = [0_u8; 4096];
+                loop {
+                    match reader.read(&mut buffer) {
+                        Ok(0) | Err(_) => break,
+                        Ok(count) => {
+                            let _ = tx.send(ProjectTerminalOutput {
+                                work_dir: work_dir.clone(),
+                                bytes: buffer[..count].to_vec(),
+                            });
+                            SignalToUI::set_ui_signal();
+                        }
+                    }
+                }
+            });
+        }
+        self.project_terminals.insert(
+            work_dir.to_path_buf(),
+            ProjectTerminalSession {
+                _child: child,
+                stdin,
+                output: String::new(),
+            },
+        );
+        Ok(())
+    }
+
+    fn run_terminal_command(&mut self, cx: &mut Cx, command: String) {
+        let Some(work_dir) = self
+            .workspace_state
+            .active_key()
+            .map(|key| key.work_dir.clone())
+        else {
+            return;
+        };
+        if let Err(error) = self.start_project_terminal(&work_dir) {
+            self.ui
+                .project_terminal(cx, ids!(project_terminal))
+                .set_output(cx, &format!("{error}\n"));
+            return;
+        }
+        let terminal = self.project_terminals.get_mut(&work_dir).unwrap();
+        terminal.output.push_str(&format!("$ {command}\n"));
+        let mut bytes = command.into_bytes();
+        bytes.push(b'\n');
+        if let Err(error) = terminal
+            .stdin
+            .write_all(&bytes)
+            .and_then(|_| terminal.stdin.flush())
+        {
+            terminal
+                .output
+                .push_str(&format!("Terminal write failed: {error}\n"));
+        }
+        self.sync_terminal_project(cx);
+    }
+
+    fn poll_terminal_output(&mut self, cx: &mut Cx) {
+        let Some(rx) = self.terminal_rx.as_ref() else {
+            return;
+        };
+        let events: Vec<_> = rx.try_iter().collect();
+        if events.is_empty() {
+            return;
+        }
+        for event in events {
+            if let Some(terminal) = self.project_terminals.get_mut(&event.work_dir) {
+                terminal
+                    .output
+                    .push_str(&String::from_utf8_lossy(&event.bytes));
+                const MAX_TERMINAL_OUTPUT: usize = 256 * 1024;
+                if terminal.output.len() > MAX_TERMINAL_OUTPUT {
+                    let cutoff = terminal.output.len() - MAX_TERMINAL_OUTPUT;
+                    let cutoff = terminal.output[cutoff..]
+                        .char_indices()
+                        .find_map(|(offset, ch)| (ch == '\n').then_some(cutoff + offset + 1))
+                        .unwrap_or(cutoff);
+                    terminal.output.drain(..cutoff);
+                }
+            }
+        }
+        self.sync_terminal_project(cx);
+    }
+
     fn select_workspace(&mut self, work_dir: PathBuf, session_id: impl Into<String>) {
         self.workspace_state
             .select(SessionKey::new(work_dir, session_id));
@@ -4027,6 +4193,7 @@ impl App {
             .text_input_ref(cx)
             .set_text(cx, &draft);
         self.refresh_attachment_ui(cx);
+        self.sync_terminal_project(cx);
     }
 
     fn push_chat(&mut self, role: MsgRole, text: impl Into<String>) {

--- a/crates/threadlane/src/app/mod.rs
+++ b/crates/threadlane/src/app/mod.rs
@@ -46,13 +46,21 @@ use std::sync::mpsc::{channel, Receiver, Sender};
 use std::sync::{Arc, Mutex};
 
 struct ProjectTerminalSession {
-    _child: Child,
+    id: u64,
+    child: Child,
     stdin: ChildStdin,
     output: String,
 }
 
+#[derive(Default)]
+struct ProjectTerminalGroup {
+    sessions: Vec<ProjectTerminalSession>,
+    active: usize,
+}
+
 struct ProjectTerminalOutput {
     work_dir: PathBuf,
+    terminal_id: u64,
     bytes: Vec<u8>,
 }
 
@@ -2428,7 +2436,9 @@ pub struct App {
     #[rust]
     starter_prompt_focus_pending: bool,
     #[rust]
-    project_terminals: HashMap<PathBuf, ProjectTerminalSession>,
+    project_terminals: HashMap<PathBuf, ProjectTerminalGroup>,
+    #[rust]
+    next_terminal_id: u64,
     #[rust]
     terminal_tx: Option<Sender<ProjectTerminalOutput>>,
     #[rust]
@@ -2439,6 +2449,7 @@ impl ScriptHook for App {}
 
 impl MatchEvent for App {
     fn handle_startup(&mut self, cx: &mut Cx) {
+        self.next_terminal_id = 1;
         let (terminal_tx, terminal_rx) = channel();
         self.terminal_tx = Some(terminal_tx);
         self.terminal_rx = Some(terminal_rx);
@@ -2669,17 +2680,32 @@ impl MatchEvent for App {
 
         self.spawn_model_fetch(api_key, account_id_opt);
         self.trigger_update_check(cx);
+        self.sync_terminal_project(cx);
 
         cx.redraw_all();
     }
 
     fn handle_actions(&mut self, cx: &mut Cx, actions: &Actions) {
-        if let Some(command) = self
+        let terminal_actions = self
             .ui
             .project_terminal(cx, ids!(project_terminal))
-            .command(actions)
-        {
-            self.run_terminal_command(cx, command);
+            .actions(actions);
+        for action in terminal_actions {
+            match action {
+                crate::components::terminal_panel::ProjectTerminalAction::Run(command) => {
+                    self.run_terminal_command(cx, command);
+                }
+                crate::components::terminal_panel::ProjectTerminalAction::New => {
+                    self.create_project_terminal(cx);
+                }
+                crate::components::terminal_panel::ProjectTerminalAction::Select(index) => {
+                    self.select_project_terminal(cx, index);
+                }
+                crate::components::terminal_panel::ProjectTerminalAction::Close(index) => {
+                    self.close_project_terminal(cx, index);
+                }
+                crate::components::terminal_panel::ProjectTerminalAction::None => {}
+            }
         }
         for action in actions {
             if let Some(ImagePickerAction::Loaded { key, attachment }) =
@@ -3905,25 +3931,52 @@ impl App {
         (api_key, account_id)
     }
 
-    fn sync_terminal_project(&mut self, cx: &mut Cx) {
-        let Some(key) = self.workspace_state.active_key() else {
-            return;
-        };
-        let project = project_name(&key.work_dir);
-        let output = self
-            .project_terminals
-            .get(&key.work_dir)
-            .map(|terminal| terminal.output.as_str())
-            .unwrap_or("Terminal ready. Run a command to start the project shell.\n");
-        let terminal = self.ui.project_terminal(cx, ids!(project_terminal));
-        terminal.set_project(cx, &project);
-        terminal.set_output(cx, output);
+    fn active_terminal_project(&self) -> Option<PathBuf> {
+        self.workspace_state
+            .active_key()
+            .map(|key| key.work_dir.clone())
     }
 
-    fn start_project_terminal(&mut self, work_dir: &Path) -> Result<(), String> {
-        if self.project_terminals.contains_key(work_dir) {
-            return Ok(());
+    fn sync_terminal_project(&mut self, cx: &mut Cx) {
+        let Some(work_dir) = self.active_terminal_project() else {
+            return;
+        };
+        let project = project_name(&work_dir);
+        let terminal = self.ui.project_terminal(cx, ids!(project_terminal));
+        terminal.set_project(cx, &project);
+        if let Some(group) = self.project_terminals.get(&work_dir) {
+            let names = group
+                .sessions
+                .iter()
+                .enumerate()
+                .map(|(index, _)| {
+                    if index == 0 {
+                        project.clone()
+                    } else {
+                        format!("{project} {}", index + 1)
+                    }
+                })
+                .collect::<Vec<_>>();
+            let output = group
+                .sessions
+                .get(group.active)
+                .map(|session| session.output.as_str())
+                .unwrap_or_default();
+            terminal.set_terminals(cx, &names, Some(group.active), output);
+        } else {
+            terminal.set_terminals(
+                cx,
+                &[],
+                None,
+                "Use + to open a terminal for this project.\n",
+            );
         }
+    }
+
+    fn spawn_project_terminal(
+        &mut self,
+        work_dir: &Path,
+    ) -> Result<ProjectTerminalSession, String> {
         let mut command = if cfg!(windows) {
             Command::new("cmd.exe")
         } else {
@@ -3950,6 +4003,8 @@ impl App {
             .terminal_tx
             .clone()
             .ok_or("Terminal channel was unavailable")?;
+        let terminal_id = self.next_terminal_id;
+        self.next_terminal_id += 1;
         for reader in [Box::new(stdout) as Box<dyn Read + Send>, Box::new(stderr)] {
             let tx = tx.clone();
             let work_dir = work_dir.to_path_buf();
@@ -3962,6 +4017,7 @@ impl App {
                         Ok(count) => {
                             let _ = tx.send(ProjectTerminalOutput {
                                 work_dir: work_dir.clone(),
+                                terminal_id,
                                 bytes: buffer[..count].to_vec(),
                             });
                             SignalToUI::set_ui_signal();
@@ -3970,32 +4026,97 @@ impl App {
                 }
             });
         }
-        self.project_terminals.insert(
-            work_dir.to_path_buf(),
-            ProjectTerminalSession {
-                _child: child,
-                stdin,
-                output: String::new(),
-            },
-        );
-        Ok(())
+        Ok(ProjectTerminalSession {
+            id: terminal_id,
+            child,
+            stdin,
+            output: String::new(),
+        })
+    }
+
+    fn create_project_terminal(&mut self, cx: &mut Cx) {
+        const MAX_PROJECT_TERMINALS: usize = 6;
+        let Some(work_dir) = self.active_terminal_project() else {
+            return;
+        };
+        if self
+            .project_terminals
+            .get(&work_dir)
+            .is_some_and(|group| group.sessions.len() >= MAX_PROJECT_TERMINALS)
+        {
+            return;
+        }
+        match self.spawn_project_terminal(&work_dir) {
+            Ok(session) => {
+                let group = self.project_terminals.entry(work_dir).or_default();
+                group.sessions.push(session);
+                group.active = group.sessions.len() - 1;
+            }
+            Err(error) => {
+                self.ui
+                    .project_terminal(cx, ids!(project_terminal))
+                    .set_terminals(cx, &[], None, &format!("{error}\n"));
+                return;
+            }
+        }
+        self.sync_terminal_project(cx);
+    }
+
+    fn select_project_terminal(&mut self, cx: &mut Cx, index: usize) {
+        let Some(work_dir) = self.active_terminal_project() else {
+            return;
+        };
+        if let Some(group) = self.project_terminals.get_mut(&work_dir) {
+            if index < group.sessions.len() {
+                group.active = index;
+            }
+        }
+        self.sync_terminal_project(cx);
+    }
+
+    fn close_project_terminal(&mut self, cx: &mut Cx, index: usize) {
+        let Some(work_dir) = self.active_terminal_project() else {
+            return;
+        };
+        let remove_group = if let Some(group) = self.project_terminals.get_mut(&work_dir) {
+            if index >= group.sessions.len() {
+                return;
+            }
+            let mut session = group.sessions.remove(index);
+            let _ = session.child.kill();
+            let _ = session.child.wait();
+            if group.sessions.is_empty() {
+                true
+            } else {
+                if group.active >= group.sessions.len() {
+                    group.active = group.sessions.len() - 1;
+                } else if index < group.active {
+                    group.active -= 1;
+                }
+                false
+            }
+        } else {
+            return;
+        };
+        if remove_group {
+            self.project_terminals.remove(&work_dir);
+        }
+        self.sync_terminal_project(cx);
     }
 
     fn run_terminal_command(&mut self, cx: &mut Cx, command: String) {
-        let Some(work_dir) = self
-            .workspace_state
-            .active_key()
-            .map(|key| key.work_dir.clone())
-        else {
+        let Some(work_dir) = self.active_terminal_project() else {
             return;
         };
-        if let Err(error) = self.start_project_terminal(&work_dir) {
-            self.ui
-                .project_terminal(cx, ids!(project_terminal))
-                .set_output(cx, &format!("{error}\n"));
-            return;
+        if !self.project_terminals.contains_key(&work_dir) {
+            self.create_project_terminal(cx);
         }
-        let terminal = self.project_terminals.get_mut(&work_dir).unwrap();
+        let Some(group) = self.project_terminals.get_mut(&work_dir) else {
+            return;
+        };
+        let Some(terminal) = group.sessions.get_mut(group.active) else {
+            return;
+        };
         terminal.output.push_str(&format!("$ {command}\n"));
         let mut bytes = command.into_bytes();
         bytes.push(b'\n');
@@ -4020,19 +4141,29 @@ impl App {
             return;
         }
         for event in events {
-            if let Some(terminal) = self.project_terminals.get_mut(&event.work_dir) {
-                terminal
-                    .output
-                    .push_str(&String::from_utf8_lossy(&event.bytes));
-                const MAX_TERMINAL_OUTPUT: usize = 256 * 1024;
-                if terminal.output.len() > MAX_TERMINAL_OUTPUT {
-                    let cutoff = terminal.output.len() - MAX_TERMINAL_OUTPUT;
-                    let cutoff = terminal.output[cutoff..]
-                        .char_indices()
-                        .find_map(|(offset, ch)| (ch == '\n').then_some(cutoff + offset + 1))
-                        .unwrap_or(cutoff);
-                    terminal.output.drain(..cutoff);
-                }
+            let Some(terminal) =
+                self.project_terminals
+                    .get_mut(&event.work_dir)
+                    .and_then(|group| {
+                        group
+                            .sessions
+                            .iter_mut()
+                            .find(|session| session.id == event.terminal_id)
+                    })
+            else {
+                continue;
+            };
+            terminal
+                .output
+                .push_str(&String::from_utf8_lossy(&event.bytes));
+            const MAX_TERMINAL_OUTPUT: usize = 256 * 1024;
+            if terminal.output.len() > MAX_TERMINAL_OUTPUT {
+                let cutoff = terminal.output.len() - MAX_TERMINAL_OUTPUT;
+                let cutoff = terminal.output[cutoff..]
+                    .char_indices()
+                    .find_map(|(offset, ch)| (ch == '\n').then_some(cutoff + offset + 1))
+                    .unwrap_or(cutoff);
+                terminal.output.drain(..cutoff);
             }
         }
         self.sync_terminal_project(cx);

--- a/crates/threadlane/src/app/mod.rs
+++ b/crates/threadlane/src/app/mod.rs
@@ -80,6 +80,7 @@ const ANTIGRAVITY_MODELS: &[&str] = &[
     "antigravity/claude-opus-4-6",
     "antigravity/gpt-oss-120b",
 ];
+const MAX_TERMINAL_OUTPUT: usize = 256 * 1024;
 
 fn append_antigravity_models(models: &mut Vec<String>) {
     for model in ANTIGRAVITY_MODELS {
@@ -190,6 +191,21 @@ fn project_name(path: &Path) -> String {
 
 fn canonical_terminal_work_dir(work_dir: &Path) -> PathBuf {
     std::fs::canonicalize(work_dir).unwrap_or_else(|_| work_dir.to_path_buf())
+}
+
+fn truncate_terminal_output(output: &mut String) {
+    if output.len() <= MAX_TERMINAL_OUTPUT {
+        return;
+    }
+    let mut cutoff = output.len() - MAX_TERMINAL_OUTPUT;
+    while cutoff < output.len() && !output.is_char_boundary(cutoff) {
+        cutoff += 1;
+    }
+    let cutoff = output[cutoff..]
+        .char_indices()
+        .find_map(|(offset, ch)| (ch == '\n').then_some(cutoff + offset + 1))
+        .unwrap_or(cutoff);
+    output.drain(..cutoff);
 }
 
 use crate::path_utils::compact_workspace_path;
@@ -4601,18 +4617,7 @@ impl App {
         for row in 0..screen.rows() {
             push_row(screen.scrollback().len() + row, screen.grid.row_slice(row));
         }
-        const MAX_TERMINAL_OUTPUT: usize = 256 * 1024;
-        if output.len() > MAX_TERMINAL_OUTPUT {
-            let mut cutoff = output.len() - MAX_TERMINAL_OUTPUT;
-            while cutoff < output.len() && !output.is_char_boundary(cutoff) {
-                cutoff += 1;
-            }
-            let cutoff = output[cutoff..]
-                .char_indices()
-                .find_map(|(offset, ch)| (ch == '\n').then_some(cutoff + offset + 1))
-                .unwrap_or(cutoff);
-            output.drain(..cutoff);
-        }
+        truncate_terminal_output(&mut output);
         output.pop();
         output
     }
@@ -5803,7 +5808,7 @@ mod workspace_header_tests {
     use super::{
         append_antigravity_models, clear_composer_for_dispatch, compact_workspace_path,
         model_credential_error, ordered_model_options, project_name, InputOrigin,
-        ANTIGRAVITY_MODELS,
+        truncate_terminal_output, ANTIGRAVITY_MODELS, MAX_TERMINAL_OUTPUT,
     };
     use crate::workspace::WorkspaceUiState;
     use std::path::Path;
@@ -5937,6 +5942,18 @@ mod workspace_header_tests {
             project_name(Path::new("/Users/alex/code/threadlane")),
             "threadlane"
         );
+    }
+
+    #[test]
+    fn terminal_output_truncation_handles_a_multibyte_cutoff() {
+        let mut output = "a".repeat(MAX_TERMINAL_OUTPUT - 1);
+        output.push('é');
+        output.push_str(&"b".repeat(MAX_TERMINAL_OUTPUT - 1));
+
+        truncate_terminal_output(&mut output);
+
+        assert!(output.is_char_boundary(0));
+        assert!(output.len() <= MAX_TERMINAL_OUTPUT);
     }
 
     #[test]

--- a/crates/threadlane/src/components/mod.rs
+++ b/crates/threadlane/src/components/mod.rs
@@ -25,6 +25,7 @@ pub mod session_row;
 pub mod sidebar_compose_button;
 pub mod status_dot;
 pub mod status_pill;
+pub mod terminal_panel;
 pub mod tool_fold_header;
 pub mod tool_section;
 
@@ -52,5 +53,6 @@ pub fn script_mod(vm: &mut ScriptVm) -> ScriptValue {
     sidebar_compose_button::script_mod(vm);
     session_row::script_mod(vm);
     status_pill::script_mod(vm);
+    terminal_panel::script_mod(vm);
     tool_section::script_mod(vm)
 }

--- a/crates/threadlane/src/components/terminal_panel.rs
+++ b/crates/threadlane/src/components/terminal_panel.rs
@@ -1,6 +1,6 @@
 //! Compact, expandable project terminal surface with project-scoped tabs.
 
-use makepad_terminal_core::{TermKeyCode as TerminalKeyCode, Terminal};
+use makepad_terminal_core::TermKeyCode as TerminalKeyCode;
 use makepad_widgets::*;
 
 script_mod! {
@@ -108,7 +108,9 @@ script_mod! {
     }
 }
 
-const MAX_VISIBLE_TERMINALS: usize = 6;
+pub const MAX_VISIBLE_TERMINALS: usize = 6;
+const TERMINAL_CELL_WIDTH: f64 = 5.7;
+const TERMINAL_CELL_HEIGHT: f64 = 12.35;
 
 fn tab_id(index: usize) -> &'static [LiveId] {
     match index {
@@ -146,7 +148,13 @@ fn slot_id(index: usize) -> &'static [LiveId] {
 #[derive(Clone, Debug, Default)]
 pub enum ProjectTerminalAction {
     Input(Vec<u8>),
-    LayoutChanged,
+    Key {
+        key: TerminalKeyCode,
+        shift: bool,
+        control: bool,
+        alt: bool,
+    },
+    LayoutChanged { cols: usize, rows: usize },
     New,
     Select(usize),
     Close(usize),
@@ -167,6 +175,8 @@ pub struct ProjectTerminal {
     #[rust]
     cursor_next_frame: NextFrame,
     #[rust]
+    layout_next_frame: NextFrame,
+    #[rust]
     cursor_last_blink: f64,
     #[rust]
     cursor_blink_on: bool,
@@ -174,6 +184,10 @@ pub struct ProjectTerminal {
     terminal_focused: bool,
     #[rust]
     output: String,
+    #[rust]
+    output_without_cursor: String,
+    #[rust]
+    output_with_cursor: String,
     #[rust]
     terminal_height: f64,
     #[rust]
@@ -190,6 +204,13 @@ impl Widget for ProjectTerminal {
     }
 
     fn handle_event(&mut self, cx: &mut Cx, event: &Event, scope: &mut Scope) {
+        if self.layout_next_frame.is_event(event).is_some() && self.expanded {
+            let (cols, rows) = self.terminal_dimensions(cx);
+            cx.widget_action(
+                self.widget_uid(),
+                ProjectTerminalAction::LayoutChanged { cols, rows },
+            );
+        }
         if self.focus_next_frame.is_event(event).is_some() && self.expanded {
             self.view.button(cx, ids!(terminal_toggle)).set_key_focus(cx);
         }
@@ -197,9 +218,25 @@ impl Widget for ProjectTerminal {
         if self.expanded && terminal_has_focus {
             match event {
                 Event::KeyDown(key) => {
-                    if let Some(bytes) = encode_key(key) {
-                        cx.widget_action(self.widget_uid(), ProjectTerminalAction::Input(bytes));
-                    } else if !key.modifiers.control && !key.modifiers.alt {
+                    if let Some(byte) = control_letter(key) {
+                        cx.widget_action(
+                            self.widget_uid(),
+                            ProjectTerminalAction::Input(vec![byte]),
+                        );
+                    } else if let Some(key_code) = terminal_key_code(key) {
+                        cx.widget_action(
+                            self.widget_uid(),
+                            ProjectTerminalAction::Key {
+                                key: key_code,
+                                shift: key.modifiers.shift,
+                                control: key.modifiers.control,
+                                alt: key.modifiers.alt,
+                            },
+                        );
+                    } else if !key.modifiers.control
+                        && !key.modifiers.alt
+                        && !key.modifiers.logo
+                    {
                         if let Some(ch) = key.key_code.to_char(key.modifiers.shift) {
                             cx.widget_action(
                                 self.widget_uid(),
@@ -313,7 +350,8 @@ impl ProjectTerminal {
             body.walk.height = Size::Fixed(height);
             body.redraw(cx);
         }
-        cx.redraw_all();
+        self.layout_next_frame = cx.new_next_frame();
+        self.view.redraw(cx);
     }
 
     pub fn toggle(&mut self, cx: &mut Cx) {
@@ -326,33 +364,45 @@ impl ProjectTerminal {
             .set_visible(cx, self.expanded);
         if self.expanded {
             self.focus_next_frame = cx.new_next_frame();
+            self.layout_next_frame = cx.new_next_frame();
             self.view.button(cx, ids!(terminal_toggle)).set_key_focus(cx);
         }
-        cx.widget_action(self.widget_uid(), ProjectTerminalAction::LayoutChanged);
         self.view.redraw(cx);
     }
 
+    fn terminal_dimensions(&self, cx: &Cx) -> (usize, usize) {
+        let rect = self.view.view(cx, ids!(terminal_scroll)).area().rect(cx);
+        terminal_grid_size(rect.size.x, rect.size.y)
+    }
+
+    fn set_output(&mut self, cx: &mut Cx, output: &str) {
+        if self.output != output {
+            self.output.clear();
+            self.output.push_str(output);
+            self.output_without_cursor = self.output.replace('\u{e000}', "");
+            self.output_with_cursor = self.output.replace('\u{e000}', "▌");
+        }
+        self.render_output(cx);
+    }
+
     fn render_output(&mut self, cx: &mut Cx) {
-        let cursor = if self.terminal_focused && self.cursor_blink_on {
-            "▌"
+        let display = if self.terminal_focused && self.cursor_blink_on {
+            &self.output_with_cursor
         } else {
-            ""
+            &self.output_without_cursor
         };
-        let display = self.output.replace('\u{e000}', cursor);
-        self.view.label(cx, ids!(terminal_output)).set_text(cx, &display);
+        self.view.label(cx, ids!(terminal_output)).set_text(cx, display);
         self.view.redraw(cx);
     }
 }
 
-fn encode_key(event: &KeyEvent) -> Option<Vec<u8>> {
-    if event.modifiers.control {
-        if let Some(ch) = event.key_code.to_char(false) {
-            let byte = ch.to_ascii_lowercase() as u8;
-            if byte.is_ascii_lowercase() {
-                return Some(vec![byte - b'a' + 1]);
-            }
-        }
-    }
+fn terminal_grid_size(width: f64, height: f64) -> (usize, usize) {
+    let cols = (width / TERMINAL_CELL_WIDTH).floor().max(1.0) as usize;
+    let rows = (height / TERMINAL_CELL_HEIGHT).floor().max(1.0) as usize;
+    (cols, rows)
+}
+
+fn terminal_key_code(event: &KeyEvent) -> Option<TerminalKeyCode> {
     let key = match event.key_code {
         KeyCode::ReturnKey | KeyCode::NumpadEnter => TerminalKeyCode::Return,
         KeyCode::Tab => TerminalKeyCode::Tab,
@@ -385,13 +435,17 @@ fn encode_key(event: &KeyEvent) -> Option<Vec<u8>> {
     if key == TerminalKeyCode::None {
         return None;
     }
-    Terminal::new(1, 1).encode_key(
-        key,
-        "",
-        event.modifiers.shift,
-        event.modifiers.control,
-        event.modifiers.alt,
-    )
+    Some(key)
+}
+
+fn control_letter(event: &KeyEvent) -> Option<u8> {
+    if event.modifiers.control && !event.modifiers.alt && !event.modifiers.logo {
+        let byte = event.key_code.to_char(false)?.to_ascii_lowercase() as u8;
+        if byte.is_ascii_lowercase() {
+            return Some(byte - b'a' + 1);
+        }
+    }
+    None
 }
 
 impl ProjectTerminalRef {
@@ -401,12 +455,16 @@ impl ProjectTerminalRef {
             .collect()
     }
 
-    pub fn set_project(&self, _cx: &mut Cx, _name: &str) {}
-
     pub fn toggle(&self, cx: &mut Cx) {
         if let Some(mut inner) = self.borrow_mut() {
             inner.toggle(cx);
         }
+    }
+
+    pub fn dimensions(&self, cx: &Cx) -> Option<(usize, usize)> {
+        self.borrow()
+            .filter(|inner| inner.expanded)
+            .map(|inner| inner.terminal_dimensions(cx))
     }
 
     pub fn set_terminals(
@@ -428,9 +486,7 @@ impl ProjectTerminalRef {
         self.button(cx, ids!(terminal_new))
             .set_visible(cx, names.len() < MAX_VISIBLE_TERMINALS);
         if let Some(mut inner) = self.borrow_mut() {
-            inner.output.clear();
-            inner.output.push_str(output);
-            inner.render_output(cx);
+            inner.set_output(cx, output);
         }
     }
 }
@@ -438,6 +494,7 @@ impl ProjectTerminalRef {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use makepad_terminal_core::Terminal;
 
     #[test]
     fn terminal_core_parses_ansi_into_screen_cells() {
@@ -448,5 +505,11 @@ mod tests {
         let text: String = screen.grid.row_slice(0).iter().map(|cell| cell.codepoint).collect();
         assert_eq!(text.trim_end(), "hellored");
         assert_ne!(screen.grid.cell(5, 0).style.fg, Default::default());
+    }
+
+    #[test]
+    fn terminal_grid_size_uses_the_visible_grid_area() {
+        assert_eq!(terminal_grid_size(570.0, 247.0), (100, 20));
+        assert_eq!(terminal_grid_size(0.0, 0.0), (1, 1));
     }
 }

--- a/crates/threadlane/src/components/terminal_panel.rs
+++ b/crates/threadlane/src/components/terminal_panel.rs
@@ -1,5 +1,6 @@
 //! Compact, expandable project terminal surface with project-scoped tabs.
 
+use makepad_terminal_core::{TermKeyCode as TerminalKeyCode, Terminal};
 use makepad_widgets::*;
 
 script_mod! {
@@ -9,12 +10,30 @@ script_mod! {
     mod.components.ProjectTerminalBase = #(ProjectTerminal::register_widget(vm))
 
     mod.components.TerminalTabButton = mod.widgets.Button {
-        width: Fit height: 28 padding: Inset{left: 9 right: 9} spacing: 0
-        draw_text +: { color: #xaeb8c5 color_hover: #xe4e9ef color_focus: #xe4e9ef color_down: #xffffff text_style: theme.font_code {font_size: 9.0} }
+        width: Fit height: 30 padding: Inset{left: 11 right: 8} spacing: 0
+        draw_text +: { color: #xaeb8c5 color_hover: #edf2f8 color_focus: #edf2f8 color_down: #ffffff text_style: theme.font_code {font_size: 9.0} }
         draw_bg +: {
-            color: #x23262b color_hover: #x2a2e34 color_focus: #x2a2e34 color_down: #x30353d
-            border_color: #x30343a border_color_hover: #x414750 border_color_focus: #x414750 border_color_down: #x4b535e
-            border_size: 1.0 border_radius: 6.0
+            color: #x00000000 color_hover: #x292f38 color_focus: #x2d3540 color_down: #x36404d
+            border_color: #x00000000 border_color_hover: #x00000000 border_color_focus: #x00000000 border_color_down: #x00000000
+            border_size: 0.0 border_radius: 4.0
+        }
+    }
+
+    mod.components.TerminalTabSlot = RoundedView {
+        width: Fit height: 34 flow: Right spacing: 0 padding: 0 align: Align{y: 0.5}
+        draw_bg +: {
+            color: #x20242a border_color: #x303741 border_size: 1.0 border_radius: 5.0
+        }
+    }
+
+    mod.components.TerminalTabCloseButton = mod.widgets.Button {
+        width: 22 height: 30 padding: 0 spacing: 0 text: "" align: Align{x: 0.5 y: 0.5}
+        icon_walk: Walk{width: 9 height: 9}
+        draw_icon +: { color: #x8390a0 color_hover: #xe3e9f0 color_focus: #xe3e9f0 color_down: #xffffff }
+        draw_bg +: {
+            color: #x00000000 color_hover: #x313a46 color_focus: #x313a46 color_down: #x3c4857
+            border_color: #x00000000 border_color_hover: #x00000000 border_color_focus: #x00000000 border_color_down: #x00000000
+            border_size: 0.0 border_radius: 4.0
         }
     }
 
@@ -23,62 +42,52 @@ script_mod! {
         icon_walk: Walk{width: 12 height: 12}
         draw_icon +: { color: #x8c98a8 color_hover: #xdde3ea color_focus: #xdde3ea color_down: #xffffff }
         draw_bg +: {
-            color: #x00000000 color_hover: #x292e35 color_focus: #x292e35 color_down: #x343a43
-            border_color: #x00000000 border_color_hover: #x00000000 border_color_focus: #x00000000 border_color_down: #x00000000 border_radius: 5.0
+            color: #x00000000 color_hover: #x252b33 color_focus: #x2b333e color_down: #x35414e
+            border_color: #x00000000 border_color_hover: #x3a4655 border_color_focus: #x50657d border_color_down: #x6e8ba8 border_radius: 5.0
         }
     }
 
     mod.components.ProjectTerminal = set_type_default() do mod.components.ProjectTerminalBase {
         width: Fill height: Fit flow: Down spacing: 4
 
-        terminal_header := RoundedView {
-            width: Fill height: 30 flow: Right padding: Inset{left: 5 right: 5} spacing: 5 align: Align{y: 0.5}
-            draw_bg +: { color: #x1d2026 border_color: #x343c48 border_size: 1.0 border_radius: 7.0 }
-            terminal_toggle := mod.components.TerminalIconButton {
-                draw_icon +: { svg: crate_resource("self:resources/icons/terminal.svg") }
-            }
-            terminal_title := Label {
-                width: Fit height: 30 padding: 0 align: Align{y: 0.5} text: "Terminal"
-                draw_text +: { color: #x9da9b8 text_style: theme.font_bold {font_size: 9.0} }
-            }
-            terminal_project := Label {
-                width: Fill height: 30 padding: 0 align: Align{y: 0.5} text: ""
-                draw_text +: { color: #x657386 text_style +: {font_size: 8.5} }
+        terminal_toggle := mod.components.TerminalIconButton {
+            width: 1
+            height: 1
+            icon_walk: Walk{width: 1 height: 1}
+            draw_icon +: {
+                svg: crate_resource("self:resources/icons/terminal.svg")
+                color: #x00000000
             }
         }
 
         terminal_body := RoundedView {
-            width: Fill height: 300 visible: false flow: Down
-            draw_bg +: { color: #x151719 border_color: #x343c48 border_size: 1.0 border_radius: 8.0 }
+            width: Fill height: 250 visible: false flow: Down
+            draw_bg +: { color: #x15181c border_color: #x303945 border_size: 1.0 border_radius: 9.0 }
 
             terminal_tabs := View {
-                width: Fill height: 38 flow: Right padding: Inset{left: 8 top: 5 right: 8 bottom: 5} spacing: 4 align: Align{y: 0.5}
-                tab_slot_0 := View {width: Fit height: 28 flow: Right spacing: 1 visible: false tab_0 := mod.components.TerminalTabButton{text: ""} close_0 := mod.components.TerminalIconButton{width: 22 draw_icon +: {svg: crate_resource("self:resources/icons/close.svg")}}}
-                tab_slot_1 := View {width: Fit height: 28 flow: Right spacing: 1 visible: false tab_1 := mod.components.TerminalTabButton{text: ""} close_1 := mod.components.TerminalIconButton{width: 22 draw_icon +: {svg: crate_resource("self:resources/icons/close.svg")}}}
-                tab_slot_2 := View {width: Fit height: 28 flow: Right spacing: 1 visible: false tab_2 := mod.components.TerminalTabButton{text: ""} close_2 := mod.components.TerminalIconButton{width: 22 draw_icon +: {svg: crate_resource("self:resources/icons/close.svg")}}}
-                tab_slot_3 := View {width: Fit height: 28 flow: Right spacing: 1 visible: false tab_3 := mod.components.TerminalTabButton{text: ""} close_3 := mod.components.TerminalIconButton{width: 22 draw_icon +: {svg: crate_resource("self:resources/icons/close.svg")}}}
-                tab_slot_4 := View {width: Fit height: 28 flow: Right spacing: 1 visible: false tab_4 := mod.components.TerminalTabButton{text: ""} close_4 := mod.components.TerminalIconButton{width: 22 draw_icon +: {svg: crate_resource("self:resources/icons/close.svg")}}}
-                tab_slot_5 := View {width: Fit height: 28 flow: Right spacing: 1 visible: false tab_5 := mod.components.TerminalTabButton{text: ""} close_5 := mod.components.TerminalIconButton{width: 22 draw_icon +: {svg: crate_resource("self:resources/icons/close.svg")}}}
-                terminal_new := mod.components.TerminalIconButton { draw_icon +: {svg: crate_resource("self:resources/icons/plus.svg")} }
+                width: Fill height: 40 flow: Right padding: Inset{left: 8 top: 3 right: 8 bottom: 3} spacing: 5 align: Align{y: 0.5}
+                tab_slot_0 := mod.components.TerminalTabSlot {visible: false tab_0 := mod.components.TerminalTabButton{text: ""} close_0 := mod.components.TerminalTabCloseButton{draw_icon +: {svg: crate_resource("self:resources/icons/close.svg")}}}
+                tab_slot_1 := mod.components.TerminalTabSlot {visible: false tab_1 := mod.components.TerminalTabButton{text: ""} close_1 := mod.components.TerminalTabCloseButton{draw_icon +: {svg: crate_resource("self:resources/icons/close.svg")}}}
+                tab_slot_2 := mod.components.TerminalTabSlot {visible: false tab_2 := mod.components.TerminalTabButton{text: ""} close_2 := mod.components.TerminalTabCloseButton{draw_icon +: {svg: crate_resource("self:resources/icons/close.svg")}}}
+                tab_slot_3 := mod.components.TerminalTabSlot {visible: false tab_3 := mod.components.TerminalTabButton{text: ""} close_3 := mod.components.TerminalTabCloseButton{draw_icon +: {svg: crate_resource("self:resources/icons/close.svg")}}}
+                tab_slot_4 := mod.components.TerminalTabSlot {visible: false tab_4 := mod.components.TerminalTabButton{text: ""} close_4 := mod.components.TerminalTabCloseButton{draw_icon +: {svg: crate_resource("self:resources/icons/close.svg")}}}
+                tab_slot_5 := mod.components.TerminalTabSlot {visible: false tab_5 := mod.components.TerminalTabButton{text: ""} close_5 := mod.components.TerminalTabCloseButton{draw_icon +: {svg: crate_resource("self:resources/icons/close.svg")}}}
+                terminal_new := mod.components.TerminalIconButton {
+                    width: 22 height: 22
+                    icon_walk: Walk{width: 9 height: 9}
+                    draw_icon +: {svg: crate_resource("self:resources/icons/plus.svg")}
+                }
             }
 
-            terminal_rule := View {width: Fill height: 1 show_bg: true draw_bg +: {color: #x2b3036}}
+            terminal_rule := View {width: Fill height: 1 show_bg: true draw_bg +: {color: #x282f38}}
             terminal_content := View {
-                width: Fill height: Fill flow: Down padding: Inset{left: 11 top: 8 right: 11 bottom: 9} spacing: 6
+                width: Fill height: Fill flow: Down padding: Inset{left: 13 top: 10 right: 13 bottom: 10} spacing: 6
                 terminal_scroll := ScrollYView {
                     width: Fill height: Fill
                     terminal_output := Label {
                         width: Fill height: Fit text: ""
                         draw_text +: {color: #xd2d7dd text_style: theme.font_code {font_size: 9.5 line_spacing: 1.3}}
                     }
-                }
-                terminal_input := TextInput {
-                    width: Fill height: 28 empty_text: "Enter a command…" is_multiline: false
-                    draw_bg +: {
-                        color: #x1d2024 color_empty: #x1d2024 color_hover: #x22272d color_focus: #x22272d color_down: #x22272d
-                        border_color: #x30363d border_color_empty: #x30363d border_color_hover: #x46505c border_color_focus: #x4a6f9e border_color_down: #x4a6f9e border_size: 1.0 border_radius: 5.0
-                    }
-                    draw_text +: {color: #xe2e7ed color_empty: #x758296 text_style: theme.font_code {font_size: 9.0}}
                 }
             }
         }
@@ -122,7 +131,8 @@ fn slot_id(index: usize) -> &'static [LiveId] {
 
 #[derive(Clone, Debug, Default)]
 pub enum ProjectTerminalAction {
-    Run(String),
+    Input(Vec<u8>),
+    LayoutChanged,
     New,
     Select(usize),
     Close(usize),
@@ -138,6 +148,18 @@ pub struct ProjectTerminal {
     view: View,
     #[rust]
     expanded: bool,
+    #[rust]
+    focus_next_frame: NextFrame,
+    #[rust]
+    cursor_next_frame: NextFrame,
+    #[rust]
+    cursor_last_blink: f64,
+    #[rust]
+    cursor_blink_on: bool,
+    #[rust]
+    terminal_focused: bool,
+    #[rust]
+    output: String,
 }
 
 impl Widget for ProjectTerminal {
@@ -146,19 +168,68 @@ impl Widget for ProjectTerminal {
     }
 
     fn handle_event(&mut self, cx: &mut Cx, event: &Event, scope: &mut Scope) {
+        if self.focus_next_frame.is_event(event).is_some() && self.expanded {
+            self.view.button(cx, ids!(terminal_toggle)).set_key_focus(cx);
+        }
+        let terminal_has_focus = self.view.button(cx, ids!(terminal_toggle)).key_focus(cx);
+        if self.expanded && terminal_has_focus {
+            match event {
+                Event::KeyDown(key) => {
+                    if let Some(bytes) = encode_key(key) {
+                        cx.widget_action(self.widget_uid(), ProjectTerminalAction::Input(bytes));
+                    } else if !key.modifiers.control && !key.modifiers.alt {
+                        if let Some(ch) = key.key_code.to_char(key.modifiers.shift) {
+                            cx.widget_action(
+                                self.widget_uid(),
+                                ProjectTerminalAction::Input(ch.to_string().into_bytes()),
+                            );
+                        }
+                    }
+                }
+                Event::TextInput(input)
+                    if input.was_paste
+                        || input.input.chars().any(|character| !character.is_ascii()) =>
+                {
+                    cx.widget_action(
+                        self.widget_uid(),
+                        ProjectTerminalAction::Input(input.input.as_bytes().to_vec()),
+                    );
+                }
+                _ => {}
+            }
+        }
         self.view.handle_event(cx, event, scope);
+        if self.expanded {
+            if let Event::MouseDown(pointer) = event {
+                let body = self.view.view(cx, ids!(terminal_body)).area().rect(cx);
+                if pointer.button.is_primary() && body.contains(pointer.abs) {
+                    self.view.button(cx, ids!(terminal_toggle)).set_key_focus(cx);
+                }
+            }
+        }
+        let focused = self.expanded && self.view.button(cx, ids!(terminal_toggle)).key_focus(cx);
+        if focused != self.terminal_focused {
+            self.terminal_focused = focused;
+            self.cursor_blink_on = focused;
+            self.cursor_last_blink = 0.0;
+            self.render_output(cx);
+            if focused {
+                self.cursor_next_frame = cx.new_next_frame();
+            }
+        }
+        if let Some(frame) = self.cursor_next_frame.is_event(event) {
+            if self.terminal_focused {
+                if frame.time - self.cursor_last_blink >= 0.45 {
+                    self.cursor_blink_on = !self.cursor_blink_on;
+                    self.cursor_last_blink = frame.time;
+                    self.render_output(cx);
+                }
+                self.cursor_next_frame = cx.new_next_frame();
+            }
+        }
         if let Event::Actions(actions) = event {
             if self.view.button(cx, ids!(terminal_toggle)).clicked(actions) {
-                self.expanded = !self.expanded;
-                self.view
-                    .view(cx, ids!(terminal_body))
-                    .set_visible(cx, self.expanded);
-                if self.expanded {
-                    self.view
-                        .text_input(cx, ids!(terminal_input))
-                        .set_key_focus(cx);
-                }
-                self.view.redraw(cx);
+                self.toggle(cx);
             }
             if self.view.button(cx, ids!(terminal_new)).clicked(actions) {
                 cx.widget_action(self.widget_uid(), ProjectTerminalAction::New);
@@ -171,16 +242,84 @@ impl Widget for ProjectTerminal {
                     cx.widget_action(self.widget_uid(), ProjectTerminalAction::Close(index));
                 }
             }
-            let input = self.view.text_input(cx, ids!(terminal_input));
-            if input.returned(actions).is_some() {
-                let command = input.text();
-                if !command.trim().is_empty() {
-                    input.set_text(cx, "");
-                    cx.widget_action(self.widget_uid(), ProjectTerminalAction::Run(command));
-                }
+        }
+    }
+}
+
+impl ProjectTerminal {
+    pub fn toggle(&mut self, cx: &mut Cx) {
+        self.expanded = !self.expanded;
+        self.view
+            .view(cx, ids!(terminal_body))
+            .set_visible(cx, self.expanded);
+        if self.expanded {
+            self.focus_next_frame = cx.new_next_frame();
+            self.view.button(cx, ids!(terminal_toggle)).set_key_focus(cx);
+        }
+        cx.widget_action(self.widget_uid(), ProjectTerminalAction::LayoutChanged);
+        self.view.redraw(cx);
+    }
+
+    fn render_output(&mut self, cx: &mut Cx) {
+        let cursor = if self.terminal_focused && self.cursor_blink_on {
+            "▌"
+        } else {
+            ""
+        };
+        let display = self.output.replace('\u{e000}', cursor);
+        self.view.label(cx, ids!(terminal_output)).set_text(cx, &display);
+        self.view.redraw(cx);
+    }
+}
+
+fn encode_key(event: &KeyEvent) -> Option<Vec<u8>> {
+    if event.modifiers.control {
+        if let Some(ch) = event.key_code.to_char(false) {
+            let byte = ch.to_ascii_lowercase() as u8;
+            if byte.is_ascii_lowercase() {
+                return Some(vec![byte - b'a' + 1]);
             }
         }
     }
+    let key = match event.key_code {
+        KeyCode::ReturnKey | KeyCode::NumpadEnter => TerminalKeyCode::Return,
+        KeyCode::Tab => TerminalKeyCode::Tab,
+        KeyCode::Backspace => TerminalKeyCode::Backspace,
+        KeyCode::Escape => TerminalKeyCode::Escape,
+        KeyCode::Delete => TerminalKeyCode::Delete,
+        KeyCode::ArrowUp => TerminalKeyCode::Up,
+        KeyCode::ArrowDown => TerminalKeyCode::Down,
+        KeyCode::ArrowLeft => TerminalKeyCode::Left,
+        KeyCode::ArrowRight => TerminalKeyCode::Right,
+        KeyCode::Home => TerminalKeyCode::Home,
+        KeyCode::End => TerminalKeyCode::End,
+        KeyCode::PageUp => TerminalKeyCode::PageUp,
+        KeyCode::PageDown => TerminalKeyCode::PageDown,
+        KeyCode::Insert => TerminalKeyCode::Insert,
+        KeyCode::F1 => TerminalKeyCode::F1,
+        KeyCode::F2 => TerminalKeyCode::F2,
+        KeyCode::F3 => TerminalKeyCode::F3,
+        KeyCode::F4 => TerminalKeyCode::F4,
+        KeyCode::F5 => TerminalKeyCode::F5,
+        KeyCode::F6 => TerminalKeyCode::F6,
+        KeyCode::F7 => TerminalKeyCode::F7,
+        KeyCode::F8 => TerminalKeyCode::F8,
+        KeyCode::F9 => TerminalKeyCode::F9,
+        KeyCode::F10 => TerminalKeyCode::F10,
+        KeyCode::F11 => TerminalKeyCode::F11,
+        KeyCode::F12 => TerminalKeyCode::F12,
+        _ => TerminalKeyCode::None,
+    };
+    if key == TerminalKeyCode::None {
+        return None;
+    }
+    Terminal::new(1, 1).encode_key(
+        key,
+        "",
+        event.modifiers.shift,
+        event.modifiers.control,
+        event.modifiers.alt,
+    )
 }
 
 impl ProjectTerminalRef {
@@ -190,8 +329,12 @@ impl ProjectTerminalRef {
             .collect()
     }
 
-    pub fn set_project(&self, cx: &mut Cx, name: &str) {
-        self.label(cx, ids!(terminal_project)).set_text(cx, name);
+    pub fn set_project(&self, _cx: &mut Cx, _name: &str) {}
+
+    pub fn toggle(&self, cx: &mut Cx) {
+        if let Some(mut inner) = self.borrow_mut() {
+            inner.toggle(cx);
+        }
     }
 
     pub fn set_terminals(
@@ -205,14 +348,33 @@ impl ProjectTerminalRef {
             let visible = index < names.len();
             self.view(cx, slot_id(index)).set_visible(cx, visible);
             if visible {
-                let prefix = if active == Some(index) { "› " } else { "" };
+                let prefix = if active == Some(index) { "● " } else { "" };
                 self.button(cx, tab_id(index))
                     .set_text(cx, &format!("{prefix}{}", names[index]));
             }
         }
         self.button(cx, ids!(terminal_new))
             .set_visible(cx, names.len() < MAX_VISIBLE_TERMINALS);
-        self.label(cx, ids!(terminal_output)).set_text(cx, output);
-        self.redraw(cx);
+        if let Some(mut inner) = self.borrow_mut() {
+            inner.output.clear();
+            inner.output.push_str(output);
+            inner.render_output(cx);
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn terminal_core_parses_ansi_into_screen_cells() {
+        let mut terminal = Terminal::new(12, 2);
+        terminal.process_bytes(b"hello\x1b[31mred");
+
+        let screen = terminal.screen();
+        let text: String = screen.grid.row_slice(0).iter().map(|cell| cell.codepoint).collect();
+        assert_eq!(text.trim_end(), "hellored");
+        assert_ne!(screen.grid.cell(5, 0).style.fg, Default::default());
     }
 }

--- a/crates/threadlane/src/components/terminal_panel.rs
+++ b/crates/threadlane/src/components/terminal_panel.rs
@@ -1,4 +1,4 @@
-//! Compact, expandable project terminal surface.
+//! Compact, expandable project terminal surface with project-scoped tabs.
 
 use makepad_widgets::*;
 
@@ -8,92 +8,124 @@ script_mod! {
 
     mod.components.ProjectTerminalBase = #(ProjectTerminal::register_widget(vm))
 
+    mod.components.TerminalTabButton = mod.widgets.Button {
+        width: Fit height: 28 padding: Inset{left: 9 right: 9} spacing: 0
+        draw_text +: { color: #xaeb8c5 color_hover: #xe4e9ef color_focus: #xe4e9ef color_down: #xffffff text_style: theme.font_code {font_size: 9.0} }
+        draw_bg +: {
+            color: #x23262b color_hover: #x2a2e34 color_focus: #x2a2e34 color_down: #x30353d
+            border_color: #x30343a border_color_hover: #x414750 border_color_focus: #x414750 border_color_down: #x4b535e
+            border_size: 1.0 border_radius: 6.0
+        }
+    }
+
+    mod.components.TerminalIconButton = mod.widgets.Button {
+        width: 28 height: 28 padding: 0 spacing: 0 text: "" align: Align{x: 0.5 y: 0.5}
+        icon_walk: Walk{width: 12 height: 12}
+        draw_icon +: { color: #x8c98a8 color_hover: #xdde3ea color_focus: #xdde3ea color_down: #xffffff }
+        draw_bg +: {
+            color: #x00000000 color_hover: #x292e35 color_focus: #x292e35 color_down: #x343a43
+            border_color: #x00000000 border_color_hover: #x00000000 border_color_focus: #x00000000 border_color_down: #x00000000 border_radius: 5.0
+        }
+    }
+
     mod.components.ProjectTerminal = set_type_default() do mod.components.ProjectTerminalBase {
-        width: Fill
-        height: Fit
-        flow: Down
+        width: Fill height: Fit flow: Down spacing: 4
 
         terminal_header := RoundedView {
-            width: Fill
-            height: 30
-            flow: Right
-            padding: Inset{left: 8 right: 8}
-            spacing: 7
-            align: Align{y: 0.5}
-            draw_bg +: { color: #x1f232b border_color: #x343c48 border_size: 1.0 border_radius: 7.0 }
-
-            terminal_toggle := Button {
-                width: 28
-                height: 26
-                padding: 0
-                spacing: 0
-                text: ""
-                align: Align{x: 0.5 y: 0.5}
-                icon_walk: Walk{width: 14 height: 14}
-                draw_icon +: {
-                    svg: crate_resource("self:resources/icons/terminal.svg")
-                    color: #x93a1b2
-                    color_hover: #xdde3ea
-                    color_focus: #xdde3ea
-                    color_down: #xffffff
-                }
-                draw_bg +: {
-                    color: #x00000000 color_hover: #x29303a color_focus: #x29303a color_down: #x343e4c
-                    border_color: #x00000000 border_color_hover: #x00000000 border_color_focus: #x00000000 border_color_down: #x00000000
-                    border_radius: 6.0
-                }
+            width: Fill height: 30 flow: Right padding: Inset{left: 5 right: 5} spacing: 5 align: Align{y: 0.5}
+            draw_bg +: { color: #x1d2026 border_color: #x343c48 border_size: 1.0 border_radius: 7.0 }
+            terminal_toggle := mod.components.TerminalIconButton {
+                draw_icon +: { svg: crate_resource("self:resources/icons/terminal.svg") }
             }
             terminal_title := Label {
-                width: Fit height: 30 padding: 0 align: Align{y: 0.5}
-                text: "Terminal"
+                width: Fit height: 30 padding: 0 align: Align{y: 0.5} text: "Terminal"
                 draw_text +: { color: #x9da9b8 text_style: theme.font_bold {font_size: 9.0} }
             }
             terminal_project := Label {
-                width: Fill height: 30 padding: 0 align: Align{y: 0.5}
-                text: ""
+                width: Fill height: 30 padding: 0 align: Align{y: 0.5} text: ""
                 draw_text +: { color: #x657386 text_style +: {font_size: 8.5} }
             }
         }
 
         terminal_body := RoundedView {
-            width: Fill
-            height: 230
-            visible: false
-            flow: Down
-            padding: Inset{left: 9 top: 7 right: 9 bottom: 7}
-            spacing: 5
-            draw_bg +: { color: #x171a20 border_color: #x343c48 border_size: 1.0 border_radius: 7.0 }
+            width: Fill height: 300 visible: false flow: Down
+            draw_bg +: { color: #x151719 border_color: #x343c48 border_size: 1.0 border_radius: 8.0 }
 
-            terminal_scroll := ScrollYView {
-                width: Fill height: Fill
-                terminal_output := Label {
-                    width: Fill height: Fit
-                    text: "Terminal ready.\n"
-                    draw_text +: {
-                        color: #xc9d1db
-                        text_style: theme.font_code {font_size: 9.0 line_spacing: 1.3}
-                        wrap: Word
+            terminal_tabs := View {
+                width: Fill height: 38 flow: Right padding: Inset{left: 8 top: 5 right: 8 bottom: 5} spacing: 4 align: Align{y: 0.5}
+                tab_slot_0 := View {width: Fit height: 28 flow: Right spacing: 1 visible: false tab_0 := mod.components.TerminalTabButton{text: ""} close_0 := mod.components.TerminalIconButton{width: 22 draw_icon +: {svg: crate_resource("self:resources/icons/close.svg")}}}
+                tab_slot_1 := View {width: Fit height: 28 flow: Right spacing: 1 visible: false tab_1 := mod.components.TerminalTabButton{text: ""} close_1 := mod.components.TerminalIconButton{width: 22 draw_icon +: {svg: crate_resource("self:resources/icons/close.svg")}}}
+                tab_slot_2 := View {width: Fit height: 28 flow: Right spacing: 1 visible: false tab_2 := mod.components.TerminalTabButton{text: ""} close_2 := mod.components.TerminalIconButton{width: 22 draw_icon +: {svg: crate_resource("self:resources/icons/close.svg")}}}
+                tab_slot_3 := View {width: Fit height: 28 flow: Right spacing: 1 visible: false tab_3 := mod.components.TerminalTabButton{text: ""} close_3 := mod.components.TerminalIconButton{width: 22 draw_icon +: {svg: crate_resource("self:resources/icons/close.svg")}}}
+                tab_slot_4 := View {width: Fit height: 28 flow: Right spacing: 1 visible: false tab_4 := mod.components.TerminalTabButton{text: ""} close_4 := mod.components.TerminalIconButton{width: 22 draw_icon +: {svg: crate_resource("self:resources/icons/close.svg")}}}
+                tab_slot_5 := View {width: Fit height: 28 flow: Right spacing: 1 visible: false tab_5 := mod.components.TerminalTabButton{text: ""} close_5 := mod.components.TerminalIconButton{width: 22 draw_icon +: {svg: crate_resource("self:resources/icons/close.svg")}}}
+                terminal_new := mod.components.TerminalIconButton { draw_icon +: {svg: crate_resource("self:resources/icons/plus.svg")} }
+            }
+
+            terminal_rule := View {width: Fill height: 1 show_bg: true draw_bg +: {color: #x2b3036}}
+            terminal_content := View {
+                width: Fill height: Fill flow: Down padding: Inset{left: 11 top: 8 right: 11 bottom: 9} spacing: 6
+                terminal_scroll := ScrollYView {
+                    width: Fill height: Fill
+                    terminal_output := Label {
+                        width: Fill height: Fit text: ""
+                        draw_text +: {color: #xd2d7dd text_style: theme.font_code {font_size: 9.5 line_spacing: 1.3}}
                     }
                 }
-            }
-            terminal_input := TextInput {
-                width: Fill height: 28
-                empty_text: "Enter a command…"
-                is_multiline: false
-                draw_bg +: {
-                    color: #x1f232b color_empty: #x1f232b color_hover: #x222832 color_focus: #x222832 color_down: #x222832
-                    border_color: #x343c48 border_color_empty: #x343c48 border_color_hover: #x465264 border_color_focus: #x4a6f9e border_color_down: #x4a6f9e
-                    border_size: 1.0 border_radius: 5.0
+                terminal_input := TextInput {
+                    width: Fill height: 28 empty_text: "Enter a command…" is_multiline: false
+                    draw_bg +: {
+                        color: #x1d2024 color_empty: #x1d2024 color_hover: #x22272d color_focus: #x22272d color_down: #x22272d
+                        border_color: #x30363d border_color_empty: #x30363d border_color_hover: #x46505c border_color_focus: #x4a6f9e border_color_down: #x4a6f9e border_size: 1.0 border_radius: 5.0
+                    }
+                    draw_text +: {color: #xe2e7ed color_empty: #x758296 text_style: theme.font_code {font_size: 9.0}}
                 }
-                draw_text +: { color: #xe2e7ed color_empty: #x758296 text_style: theme.font_code {font_size: 9.0} }
             }
         }
+    }
+}
+
+const MAX_VISIBLE_TERMINALS: usize = 6;
+
+fn tab_id(index: usize) -> &'static [LiveId] {
+    match index {
+        0 => ids!(tab_0),
+        1 => ids!(tab_1),
+        2 => ids!(tab_2),
+        3 => ids!(tab_3),
+        4 => ids!(tab_4),
+        _ => ids!(tab_5),
+    }
+}
+
+fn close_id(index: usize) -> &'static [LiveId] {
+    match index {
+        0 => ids!(close_0),
+        1 => ids!(close_1),
+        2 => ids!(close_2),
+        3 => ids!(close_3),
+        4 => ids!(close_4),
+        _ => ids!(close_5),
+    }
+}
+
+fn slot_id(index: usize) -> &'static [LiveId] {
+    match index {
+        0 => ids!(tab_slot_0),
+        1 => ids!(tab_slot_1),
+        2 => ids!(tab_slot_2),
+        3 => ids!(tab_slot_3),
+        4 => ids!(tab_slot_4),
+        _ => ids!(tab_slot_5),
     }
 }
 
 #[derive(Clone, Debug, Default)]
 pub enum ProjectTerminalAction {
     Run(String),
+    New,
+    Select(usize),
+    Close(usize),
     #[default]
     None,
 }
@@ -128,6 +160,17 @@ impl Widget for ProjectTerminal {
                 }
                 self.view.redraw(cx);
             }
+            if self.view.button(cx, ids!(terminal_new)).clicked(actions) {
+                cx.widget_action(self.widget_uid(), ProjectTerminalAction::New);
+            }
+            for index in 0..MAX_VISIBLE_TERMINALS {
+                if self.view.button(cx, tab_id(index)).clicked(actions) {
+                    cx.widget_action(self.widget_uid(), ProjectTerminalAction::Select(index));
+                }
+                if self.view.button(cx, close_id(index)).clicked(actions) {
+                    cx.widget_action(self.widget_uid(), ProjectTerminalAction::Close(index));
+                }
+            }
             let input = self.view.text_input(cx, ids!(terminal_input));
             if input.returned(actions).is_some() {
                 let command = input.text();
@@ -141,20 +184,34 @@ impl Widget for ProjectTerminal {
 }
 
 impl ProjectTerminalRef {
-    pub fn command(&self, actions: &Actions) -> Option<String> {
+    pub fn actions(&self, actions: &Actions) -> Vec<ProjectTerminalAction> {
         actions
             .filter_widget_actions_cast::<ProjectTerminalAction>(self.widget_uid())
-            .find_map(|action| match action {
-                ProjectTerminalAction::Run(command) => Some(command),
-                ProjectTerminalAction::None => None,
-            })
+            .collect()
     }
 
     pub fn set_project(&self, cx: &mut Cx, name: &str) {
         self.label(cx, ids!(terminal_project)).set_text(cx, name);
     }
 
-    pub fn set_output(&self, cx: &mut Cx, output: &str) {
+    pub fn set_terminals(
+        &self,
+        cx: &mut Cx,
+        names: &[String],
+        active: Option<usize>,
+        output: &str,
+    ) {
+        for index in 0..MAX_VISIBLE_TERMINALS {
+            let visible = index < names.len();
+            self.view(cx, slot_id(index)).set_visible(cx, visible);
+            if visible {
+                let prefix = if active == Some(index) { "› " } else { "" };
+                self.button(cx, tab_id(index))
+                    .set_text(cx, &format!("{prefix}{}", names[index]));
+            }
+        }
+        self.button(cx, ids!(terminal_new))
+            .set_visible(cx, names.len() < MAX_VISIBLE_TERMINALS);
         self.label(cx, ids!(terminal_output)).set_text(cx, output);
         self.redraw(cx);
     }

--- a/crates/threadlane/src/components/terminal_panel.rs
+++ b/crates/threadlane/src/components/terminal_panel.rs
@@ -60,6 +60,20 @@ script_mod! {
             }
         }
 
+        terminal_resize_handle := View {
+            width: Fill height: 6 visible: false
+            show_bg: true
+            draw_bg +: {
+                color: #x2a3440
+                pixel: fn() {
+                    let sdf = Sdf2d.viewport(self.pos * self.rect_size)
+                    sdf.clear(#x00000000)
+                    sdf.rect(0.0, self.rect_size.y * 0.5 - 0.5, self.rect_size.x, 1.0)
+                    return sdf.fill(self.color)
+                }
+            }
+        }
+
         terminal_body := RoundedView {
             width: Fill height: 250 visible: false flow: Down
             draw_bg +: { color: #x15181c border_color: #x303945 border_size: 1.0 border_radius: 9.0 }
@@ -160,6 +174,14 @@ pub struct ProjectTerminal {
     terminal_focused: bool,
     #[rust]
     output: String,
+    #[rust]
+    terminal_height: f64,
+    #[rust]
+    resizing: bool,
+    #[rust]
+    resize_start_y: f64,
+    #[rust]
+    resize_start_height: f64,
 }
 
 impl Widget for ProjectTerminal {
@@ -199,6 +221,44 @@ impl Widget for ProjectTerminal {
             }
         }
         self.view.handle_event(cx, event, scope);
+        match event {
+            Event::MouseDown(pointer)
+                if self.expanded
+                    && pointer.button.is_primary()
+                    && self
+                        .view
+                        .view(cx, ids!(terminal_resize_handle))
+                        .area()
+                        .rect(cx)
+                        .contains(pointer.abs) =>
+            {
+                self.resizing = true;
+                self.resize_start_y = pointer.abs.y;
+                self.resize_start_height = self.terminal_height.max(250.0);
+                cx.set_cursor(MouseCursor::RowResize);
+            }
+            Event::MouseMove(pointer) if self.resizing => {
+                self.set_terminal_height(
+                    cx,
+                    (self.resize_start_height + self.resize_start_y - pointer.abs.y)
+                        .clamp(160.0, 520.0),
+                );
+                cx.set_cursor(MouseCursor::RowResize);
+            }
+            Event::MouseMove(pointer)
+                if self.expanded
+                    && self
+                        .view
+                        .view(cx, ids!(terminal_resize_handle))
+                        .area()
+                        .rect(cx)
+                        .contains(pointer.abs) =>
+            {
+                cx.set_cursor(MouseCursor::RowResize);
+            }
+            Event::MouseUp(pointer) if pointer.button.is_primary() => self.resizing = false,
+            _ => {}
+        }
         if self.expanded {
             if let Event::MouseDown(pointer) = event {
                 let body = self.view.view(cx, ids!(terminal_body)).area().rect(cx);
@@ -247,10 +307,22 @@ impl Widget for ProjectTerminal {
 }
 
 impl ProjectTerminal {
+    fn set_terminal_height(&mut self, cx: &mut Cx, height: f64) {
+        self.terminal_height = height;
+        if let Some(mut body) = self.view.view(cx, ids!(terminal_body)).borrow_mut() {
+            body.walk.height = Size::Fixed(height);
+            body.redraw(cx);
+        }
+        cx.redraw_all();
+    }
+
     pub fn toggle(&mut self, cx: &mut Cx) {
         self.expanded = !self.expanded;
         self.view
             .view(cx, ids!(terminal_body))
+            .set_visible(cx, self.expanded);
+        self.view
+            .view(cx, ids!(terminal_resize_handle))
             .set_visible(cx, self.expanded);
         if self.expanded {
             self.focus_next_frame = cx.new_next_frame();

--- a/crates/threadlane/src/components/terminal_panel.rs
+++ b/crates/threadlane/src/components/terminal_panel.rs
@@ -1,0 +1,161 @@
+//! Compact, expandable project terminal surface.
+
+use makepad_widgets::*;
+
+script_mod! {
+    use mod.prelude.widgets.*
+    use mod.components.*
+
+    mod.components.ProjectTerminalBase = #(ProjectTerminal::register_widget(vm))
+
+    mod.components.ProjectTerminal = set_type_default() do mod.components.ProjectTerminalBase {
+        width: Fill
+        height: Fit
+        flow: Down
+
+        terminal_header := RoundedView {
+            width: Fill
+            height: 30
+            flow: Right
+            padding: Inset{left: 8 right: 8}
+            spacing: 7
+            align: Align{y: 0.5}
+            draw_bg +: { color: #x1f232b border_color: #x343c48 border_size: 1.0 border_radius: 7.0 }
+
+            terminal_toggle := Button {
+                width: 28
+                height: 26
+                padding: 0
+                spacing: 0
+                text: ""
+                align: Align{x: 0.5 y: 0.5}
+                icon_walk: Walk{width: 14 height: 14}
+                draw_icon +: {
+                    svg: crate_resource("self:resources/icons/terminal.svg")
+                    color: #x93a1b2
+                    color_hover: #xdde3ea
+                    color_focus: #xdde3ea
+                    color_down: #xffffff
+                }
+                draw_bg +: {
+                    color: #x00000000 color_hover: #x29303a color_focus: #x29303a color_down: #x343e4c
+                    border_color: #x00000000 border_color_hover: #x00000000 border_color_focus: #x00000000 border_color_down: #x00000000
+                    border_radius: 6.0
+                }
+            }
+            terminal_title := Label {
+                width: Fit height: 30 padding: 0 align: Align{y: 0.5}
+                text: "Terminal"
+                draw_text +: { color: #x9da9b8 text_style: theme.font_bold {font_size: 9.0} }
+            }
+            terminal_project := Label {
+                width: Fill height: 30 padding: 0 align: Align{y: 0.5}
+                text: ""
+                draw_text +: { color: #x657386 text_style +: {font_size: 8.5} }
+            }
+        }
+
+        terminal_body := RoundedView {
+            width: Fill
+            height: 230
+            visible: false
+            flow: Down
+            padding: Inset{left: 9 top: 7 right: 9 bottom: 7}
+            spacing: 5
+            draw_bg +: { color: #x171a20 border_color: #x343c48 border_size: 1.0 border_radius: 7.0 }
+
+            terminal_scroll := ScrollYView {
+                width: Fill height: Fill
+                terminal_output := Label {
+                    width: Fill height: Fit
+                    text: "Terminal ready.\n"
+                    draw_text +: {
+                        color: #xc9d1db
+                        text_style: theme.font_code {font_size: 9.0 line_spacing: 1.3}
+                        wrap: Word
+                    }
+                }
+            }
+            terminal_input := TextInput {
+                width: Fill height: 28
+                empty_text: "Enter a command…"
+                is_multiline: false
+                draw_bg +: {
+                    color: #x1f232b color_empty: #x1f232b color_hover: #x222832 color_focus: #x222832 color_down: #x222832
+                    border_color: #x343c48 border_color_empty: #x343c48 border_color_hover: #x465264 border_color_focus: #x4a6f9e border_color_down: #x4a6f9e
+                    border_size: 1.0 border_radius: 5.0
+                }
+                draw_text +: { color: #xe2e7ed color_empty: #x758296 text_style: theme.font_code {font_size: 9.0} }
+            }
+        }
+    }
+}
+
+#[derive(Clone, Debug, Default)]
+pub enum ProjectTerminalAction {
+    Run(String),
+    #[default]
+    None,
+}
+
+#[derive(Script, ScriptHook, Widget)]
+pub struct ProjectTerminal {
+    #[source]
+    source: ScriptObjectRef,
+    #[deref]
+    view: View,
+    #[rust]
+    expanded: bool,
+}
+
+impl Widget for ProjectTerminal {
+    fn draw_walk(&mut self, cx: &mut Cx2d, scope: &mut Scope, walk: Walk) -> DrawStep {
+        self.view.draw_walk(cx, scope, walk)
+    }
+
+    fn handle_event(&mut self, cx: &mut Cx, event: &Event, scope: &mut Scope) {
+        self.view.handle_event(cx, event, scope);
+        if let Event::Actions(actions) = event {
+            if self.view.button(cx, ids!(terminal_toggle)).clicked(actions) {
+                self.expanded = !self.expanded;
+                self.view
+                    .view(cx, ids!(terminal_body))
+                    .set_visible(cx, self.expanded);
+                if self.expanded {
+                    self.view
+                        .text_input(cx, ids!(terminal_input))
+                        .set_key_focus(cx);
+                }
+                self.view.redraw(cx);
+            }
+            let input = self.view.text_input(cx, ids!(terminal_input));
+            if input.returned(actions).is_some() {
+                let command = input.text();
+                if !command.trim().is_empty() {
+                    input.set_text(cx, "");
+                    cx.widget_action(self.widget_uid(), ProjectTerminalAction::Run(command));
+                }
+            }
+        }
+    }
+}
+
+impl ProjectTerminalRef {
+    pub fn command(&self, actions: &Actions) -> Option<String> {
+        actions
+            .filter_widget_actions_cast::<ProjectTerminalAction>(self.widget_uid())
+            .find_map(|action| match action {
+                ProjectTerminalAction::Run(command) => Some(command),
+                ProjectTerminalAction::None => None,
+            })
+    }
+
+    pub fn set_project(&self, cx: &mut Cx, name: &str) {
+        self.label(cx, ids!(terminal_project)).set_text(cx, name);
+    }
+
+    pub fn set_output(&self, cx: &mut Cx, output: &str) {
+        self.label(cx, ids!(terminal_output)).set_text(cx, output);
+        self.redraw(cx);
+    }
+}


### PR DESCRIPTION
### Motivation

- Provide an inline, project-attached terminal below the chat composer that expands into a simple command/output surface mirroring Makepad Studio’s terminal behavior. 
- Keep a single persistent shell per project so switching between sessions inside the same project preserves terminal state and output. 

### Description

- Add a reusable Makepad script widget `ProjectTerminal` in `crates/threadlane/src/components/terminal_panel.rs` that renders a compact header row with a terminal icon, project label, and an expandable body containing output and an input line. 
- Register the component in `crates/threadlane/src/components/mod.rs` and insert `project_terminal := mod.components.ProjectTerminal {}` into the app UI in `crates/threadlane/src/app/mod.rs`. 
- Implement per-project shell state in `App`: add `ProjectTerminalSession` and `ProjectTerminalOutput` types, a sender/receiver channel pair, and `project_terminals` map to hold running shells keyed by canonical `work_dir`. 
- Spawn a real shell process per project via `start_project_terminal`, stream its `stdout`/`stderr` back on background threads into the UI channel, and call `SignalToUI::set_ui_signal()` to wake the Makepad thread. 
- Wire command submission from the widget to `run_terminal_command`, forward input to the child stdin, and append `$ <command>` to the retained output. 
- Add `poll_terminal_output` and `sync_terminal_project` to collect channel events, append text to the retained per-project output buffer, cap retained output to 256 KiB, and update the widget view. 
- Document the lifecycle convention in `AGENTS.md` (project-keyed terminals). 

### Testing

- Ran `cargo check -p threadlane` and the focused compile check completed successfully. 
- Ran `rustfmt --edition 2021 --check` (targeting the modified files) and formatting check passed. 
- Ran `git diff --check` to validate whitespace and patch hygiene and it passed. 
- Note: full workspace `cargo test` and Makepad Studio runtime visual verification were not performed here because the Studio remote endpoint was not available in the environment; the implementation uses background threads and `SignalToUI` so runtime visual checks are recommended when running the app in a local Studio session.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a64ed864f44832e8e67896b294285ff)