### PR TITLE
🧹 Remove dead code format_git_branch_label

### DIFF
--- a/crates/threadlane/src/panels/git/view.rs
+++ b/crates/threadlane/src/panels/git/view.rs
@@ -2,19 +2,6 @@
 
 use crate::git::GitStatus;
 
-#[allow(dead_code)]
-pub fn format_git_branch_label(status: &GitStatus) -> String {
-    if let Some(branch) = &status.branch {
-        if status.detached {
-            format!("detached @ {}", branch)
-        } else {
-            branch.clone()
-        }
-    } else {
-        "No branch".to_string()
-    }
-}
-
 pub fn git_branch_picker_labels(status: Option<&GitStatus>) -> (Vec<String>, usize) {
     let mut labels = status
         .map(|status| status.branches.clone())


### PR DESCRIPTION
🎯 **What:** Removed the explicitly marked unused function `format_git_branch_label` from `crates/threadlane/src/panels/git/view.rs`.
💡 **Why:** To improve code health by removing unmaintained, dead code that is no longer needed by the UI.
✅ **Verification:** Ran `cargo test` and verified all tests pass, ensuring no existing functionality is broken.
✨ **Result:** A cleaner `view.rs` file and improved overall codebase maintainability without behavior changes.

---
*PR created automatically by Jules for task [14697494504727477393](https://jules.google.com/task/14697494504727477393) started by @wheregmis*