### PR TITLE
Refactor SettingsActionButton

### DIFF
--- a/crates/threadlane/src/app/mod.rs
+++ b/crates/threadlane/src/app/mod.rs
@@ -964,31 +964,6 @@ script_mod! {
         }
     }
 
-    let SettingsActionButton = Button {
-        width: Fit
-        height: 28
-        padding: Inset{left: 10 right: 10 top: 4 bottom: 4}
-        draw_bg +: {
-            color: theme.color_card
-            color_hover: theme.color_secondary
-            color_focus: theme.color_secondary
-            color_down: theme.color_input
-            border_color: theme.color_secondary
-            border_color_hover: theme.color_primary
-            border_color_focus: theme.color_primary
-            border_color_down: theme.color_primary
-            border_size: 1.0
-            border_radius: 6.0
-        }
-        draw_text +: {
-            color: theme.color_card_foreground
-            color_hover: theme.color_foreground
-            color_focus: theme.color_primary_foreground
-            color_down: theme.color_primary_foreground
-            text_style +: { font_size: 9.0 }
-        }
-    }
-
     let ProvidersModal = #(ProviderSettingsModal::register_widget(vm)) {
         width: Fill
         height: Fill
@@ -1298,12 +1273,12 @@ script_mod! {
                                 text_style +: { font_size: 8.75 }
                             }
                         }
-                        capability_scope_global_btn := SettingsActionButton {
+                        capability_scope_global_btn := mod.components.SettingsActionButton {
                             height: 24
                             padding: Inset{left: 8 right: 8 top: 2 bottom: 2}
                             text: "Global"
                         }
-                        capability_scope_project_btn := SettingsActionButton {
+                        capability_scope_project_btn := mod.components.SettingsActionButton {
                             height: 24
                             padding: Inset{left: 8 right: 8 top: 2 bottom: 2}
                             text: "Project"
@@ -1460,12 +1435,12 @@ script_mod! {
                             }
                         }
 
-                        mcp_scope_global_btn := SettingsActionButton {
+                        mcp_scope_global_btn := mod.components.SettingsActionButton {
                             height: 24
                             padding: Inset{left: 8 right: 8 top: 2 bottom: 2}
                             text: "Global"
                         }
-                        mcp_scope_project_btn := SettingsActionButton {
+                        mcp_scope_project_btn := mod.components.SettingsActionButton {
                             height: 24
                             padding: Inset{left: 8 right: 8 top: 2 bottom: 2}
                             text: "Project"
@@ -1560,7 +1535,7 @@ script_mod! {
                                 }
                             }
 
-                            mcp_submit_add_btn := SettingsActionButton {
+                            mcp_submit_add_btn := mod.components.SettingsActionButton {
                                 height: 28
                                 padding: Inset{left: 12 right: 12 top: 4 bottom: 4}
                                 text: "Add"

--- a/crates/threadlane/src/components/mod.rs
+++ b/crates/threadlane/src/components/mod.rs
@@ -32,6 +32,7 @@ pub mod provider_card;
 pub mod search_input;
 pub mod section_header;
 pub mod session_row;
+pub mod settings_action_button;
 pub mod sidebar_compose_button;
 pub mod status_dot;
 pub mod status_pill;
@@ -74,6 +75,7 @@ pub fn script_mod(vm: &mut ScriptVm) -> ScriptValue {
     provider_card::script_mod(vm);
     sidebar_compose_button::script_mod(vm);
     session_row::script_mod(vm);
+    settings_action_button::script_mod(vm);
     status_pill::script_mod(vm);
     starter_prompt_card::script_mod(vm);
     task_sidebar::script_mod(vm);

--- a/crates/threadlane/src/components/settings_action_button.rs
+++ b/crates/threadlane/src/components/settings_action_button.rs
@@ -1,0 +1,65 @@
+//! Shared settings action button styling and selected-state synchronization.
+
+use makepad_widgets::*;
+
+
+script_mod! {
+    use mod.prelude.widgets.*
+
+    mod.components.SettingsActionButton = Button {
+        width: Fit
+        height: 28
+        padding: Inset{left: 10 right: 10 top: 4 bottom: 4}
+
+        draw_bg +: {
+            border_size: 1.0
+            border_radius: 6.0
+            color: theme.color_card
+            color_hover: theme.color_secondary
+            color_focus: theme.color_secondary
+            color_down: theme.color_input
+            border_color: theme.color_secondary
+            border_color_hover: theme.color_primary
+            border_color_focus: theme.color_primary
+            border_color_down: theme.color_primary
+        }
+
+        draw_text +: {
+            color: theme.color_card_foreground
+            color_hover: theme.color_foreground
+            color_focus: theme.color_primary_foreground
+            color_down: theme.color_primary_foreground
+            text_style +: { font_size: 9.0 }
+        }
+
+        animator: Animator{
+            selected: {
+                default: @off
+                off: AnimatorState{
+                    from: {all: Forward {duration: 0.}}
+                    apply: {
+                        draw_bg: {
+                            color: theme.color_card
+                            border_color: theme.color_secondary
+                        }
+                        draw_text: {
+                            color: theme.color_card_foreground
+                        }
+                    }
+                }
+                on: AnimatorState{
+                    from: {all: Forward {duration: 0.}}
+                    apply: {
+                        draw_bg: {
+                            color: theme.color_primary
+                            border_color: theme.color_primary
+                        }
+                        draw_text: {
+                            color: theme.color_primary_foreground
+                        }
+                    }
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
Extracted `SettingsActionButton` from `crates/threadlane/src/app/mod.rs` into its own component in `crates/threadlane/src/components/settings_action_button.rs`. 
Replaced all inline usages with `mod.components.SettingsActionButton`. Registered the new component.

---
*PR created automatically by Jules for task [14017481755486665738](https://jules.google.com/task/14017481755486665738) started by @wheregmis*