### PR TITLE
feat(settings): ACP agent configuration page

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -299,6 +299,10 @@ If changing ordering, row height, popup padding, or selected-item behavior, upda
 - That guard resolves a not-yet-existing target by joining the remaining components onto its canonicalized nearest existing ancestor, then comparing against the canonical root. Never compare a lexical path against the canonical root: a workspace reached through a symlink is spelled two ways (`/tmp/...` and `/private/tmp/...` on macOS), so the lexical check rejects valid new files anywhere under it.
 - The default `AcpPermissionPolicy` is `Reject`. An unattended client has no informed consent to give, so auto-approval must stay opt-in and any UI-backed handler should prompt rather than raise this default.
 - Build connections through `AcpConnection::from_streams` when testing. `tests/acp_tests.rs` pairs the client with an in-process stub agent over `tokio::io::duplex`, which covers framing, request correlation, and the sandbox without depending on an installed agent binary.
+- The settings modal has a dedicated `acp_page` whose scope buttons share the modal's single `install_scope_global` flag with the WASI and MCP pages; register new scope buttons in both `sync_install_scope` and the scope-click handlers rather than adding a second scope flag.
+- `ProviderSettingsModal::draw_walk` selects a `PortalList` branch by `self.page`, which is only correct because non-selected pages are invisible and therefore never draw. Any new capability page must add its branch there and its widget to `sync_page_visibility`, or its rows silently render into another page's list.
+- `refresh_acp_state` renders configured agents from disk immediately with `Connecting` status, then replaces them when the background probe reports through `AcpRefreshCompleted`. Probing spawns processes and each handshake can take seconds, so never probe on the UI thread and never leave the list blank while it runs.
+- Opening the settings modal must not probe ACP agents. Probing starts only when the ACP page is selected or refreshed, so merely opening settings never launches third-party binaries.
 
 ## Updater Behavior
 

--- a/README.md
+++ b/README.md
@@ -47,6 +47,7 @@ Threadlane combines a GPU-accelerated desktop interface with a capable coding-ag
 | Session trees | Fork, clone, navigate, persist, and compact branching conversation history. |
 | Provider integration | OpenAI-compatible streaming, Codex-oriented models, reasoning controls, device authorization, and credential persistence. |
 | WASI extensions | Sandboxed Wasm modules using the `threadlane_host` capability broker. |
+| ACP agents | Configure external Agent Client Protocol agents per project or globally, and check that each one launches and handshakes. |
 | Signed updater | Background update checks, verified downloads, progress UI, and packaged-app installation/relaunch. |
 
 ## How It Fits Together
@@ -148,6 +149,7 @@ Threadlane keeps application state local:
 - Project sessions: `<project>/.threadlane/sessions/`
 - Project extensions, agents, prompts, and skills: `<project>/.threadlane/`
 - Global extensions, agents, and skills: `~/.threadlane/` and `~/.agents/skills/`
+- ACP agent configuration: `~/.threadlane/acp.json` and `<project>/.threadlane/acp.json`
 
 Treat these directories as user data. Back them up before manually migrating or removing state.
 
@@ -211,6 +213,50 @@ Threadlane reads identity and version information from the module's exported
 `extension_info` manifest; it does not run Cargo or extension build scripts.
 An enabled project module overrides an enabled global module with the same
 manifest name. Each scope can be enabled, disabled, or removed independently.
+
+## External ACP Agents
+
+Threadlane can talk to third-party coding agents that implement the
+[Agent Client Protocol](https://agentclientprotocol.com). It acts as the ACP
+*client*: it launches the agent as a subprocess and speaks JSON-RPC over its
+stdio pipes.
+
+The **ACP Agents** settings page lists agents from `~/.threadlane/acp.json` and
+`<project>/.threadlane/acp.json`. Choose Global or Project scope, give the agent
+a name and the command that starts it, and press Add:
+
+| Agent | Command |
+| --- | --- |
+| Gemini CLI | `gemini --experimental-acp` |
+| Claude Code | `npx -y @zed-industries/claude-code-acp` |
+
+Refresh launches each enabled agent, completes the ACP handshake, and reports
+the agent name, negotiated protocol version, and whether it still needs to be
+signed in. An agent that cannot be spawned shows the launch error instead, so a
+missing binary or a wrong command is visible without leaving the settings page.
+Agents can be enabled, disabled, or removed per scope, and a project entry
+shadows a global entry with the same id.
+
+The configuration file can also be edited directly:
+
+```json
+{
+  "agents": [
+    {
+      "id": "gemini",
+      "name": "Gemini CLI",
+      "command": "gemini",
+      "args": ["--experimental-acp"],
+      "enabled": true
+    }
+  ]
+}
+```
+
+ACP has no HTTP transport, so an agent is always a local command. Threadlane
+grants a connected agent workspace-scoped file access only: reads and writes
+that resolve outside the project root are refused. Tool-permission requests are
+declined unless a handler is configured to answer them.
 
 ## Development
 

--- a/crates/threadlane/src/app/mod.rs
+++ b/crates/threadlane/src/app/mod.rs
@@ -984,6 +984,10 @@ script_mod! {
                     text: "MCP Servers"
                 }
 
+                settings_nav_acp_btn := mod.components.NavButton {
+                    text: "ACP Agents"
+                }
+
                 settings_nav_about_btn := mod.components.NavButton {
                     text: "About"
                 }
@@ -1460,6 +1464,169 @@ script_mod! {
                     }
 
                     mcp_status_lbl := Label {
+                        width: Fill
+                        height: Fit
+                        padding: 0
+                        text: ""
+                        draw_text +: {
+                            color: theme.color_primary
+                            text_style +: { font_size: 9.5 }
+                        }
+                    }
+                }
+
+                acp_page := View {
+                    width: Fill
+                    height: Fill
+                    flow: Down
+                    spacing: 12
+                    visible: false
+
+                    acp_header := View {
+                        width: Fill
+                        height: 28
+                        flow: Right
+                        spacing: 6
+                        align: Align{y: 0.5}
+
+                        acp_page_title := Label {
+                            width: Fill
+                            height: 28
+                            padding: 0
+                            align: Align{y: 0.5}
+                            text: "ACP Agents"
+                            draw_text +: {
+                                color: theme.color_foreground
+                                text_style: theme.font_bold { font_size: 18.0 }
+                            }
+                        }
+
+                        acp_scope_global_btn := SettingsActionButton {
+                            height: 24
+                            padding: Inset{left: 8 right: 8 top: 2 bottom: 2}
+                            text: "Global"
+                        }
+                        acp_scope_project_btn := SettingsActionButton {
+                            height: 24
+                            padding: Inset{left: 8 right: 8 top: 2 bottom: 2}
+                            text: "Project"
+                            draw_bg +: {
+                                color: theme.color_primary
+                                border_color: theme.color_primary
+                            }
+                        }
+                        acp_refresh_btn := mod.components.IconButton {
+                            draw_icon +: {
+                                svg: crate_resource("self:resources/icons/refresh.svg")
+                            }
+                        }
+                    }
+
+                    acp_page_desc := Label {
+                        width: Fill
+                        height: Fit
+                        padding: 0
+                        text: "External coding agents that speak the Agent Client Protocol over stdio."
+                        draw_text +: {
+                            color: theme.color_muted_foreground
+                            text_style +: { font_size: 10.0 }
+                        }
+                    }
+
+                    acp_add_card := RoundedView {
+                        width: Fill
+                        height: Fit
+                        flow: Down
+                        padding: Inset{left: 12 top: 10 right: 12 bottom: 10}
+                        spacing: 8
+                        draw_bg +: {
+                            color: theme.color_card
+                            border_radius: 8.0
+                            border_size: 1.0
+                            border_color: theme.color_input
+                        }
+
+                        acp_add_title := Label {
+                            width: Fill
+                            height: Fit
+                            text: "Add ACP Agent"
+                            draw_text +: {
+                                color: theme.color_foreground
+                                text_style: theme.font_bold { font_size: 11.0 }
+                            }
+                        }
+
+                        acp_add_inputs := View {
+                            width: Fill
+                            height: Fit
+                            flow: Right
+                            spacing: 8
+                            align: Align{y: 0.5}
+
+                            acp_name_input := TextInput {
+                                width: 140
+                                height: 28
+                                padding: Inset{left: 8 right: 8}
+                                empty_text: "Name (e.g. Gemini)"
+                                draw_bg +: {
+                                    color: theme.color_input
+                                    color_focus: theme.color_input
+                                    border_color: theme.color_secondary
+                                    border_color_focus: theme.color_primary
+                                    border_radius: 5.0
+                                    border_size: 1.0
+                                }
+                                draw_text +: {
+                                    color: theme.color_foreground
+                                    color_empty: theme.color_muted_foreground
+                                }
+                            }
+
+                            acp_command_input := TextInput {
+                                width: Fill
+                                height: 28
+                                padding: Inset{left: 8 right: 8}
+                                empty_text: "Command (e.g. gemini --experimental-acp)"
+                                draw_bg +: {
+                                    color: theme.color_input
+                                    color_focus: theme.color_input
+                                    border_color: theme.color_secondary
+                                    border_color_focus: theme.color_primary
+                                    border_radius: 5.0
+                                    border_size: 1.0
+                                }
+                                draw_text +: {
+                                    color: theme.color_foreground
+                                    color_empty: theme.color_muted_foreground
+                                }
+                            }
+
+                            acp_submit_add_btn := SettingsActionButton {
+                                height: 28
+                                padding: Inset{left: 12 right: 12 top: 4 bottom: 4}
+                                text: "Add"
+                                draw_bg +: {
+                                    color: theme.color_primary
+                                    border_color: theme.color_primary
+                                }
+                            }
+                        }
+                    }
+
+                    acp_list := PortalList {
+                        width: Fill
+                        height: Fill
+                        flow: Down
+                        spacing: 8
+
+                        AcpRow := mod.components.CapabilityRowWithRemove {}
+
+                        AcpEmptyRow := mod.components.CapabilityEmptyRow {
+                            empty_lbl: { text: "No ACP agents configured." }
+                        }
+                    }
+
+                    acp_status_lbl := Label {
                         width: Fill
                         height: Fit
                         padding: 0
@@ -4814,6 +4981,191 @@ impl App {
         }
     }
 
+    fn set_acp_status(&mut self, cx: &mut Cx, status: &str) {
+        if let Some(mut modal) = self
+            .ui
+            .widget(cx, ids!(providers_modal))
+            .borrow_mut::<ProviderSettingsModal>()
+        {
+            modal.set_acp_status(cx, status);
+        }
+    }
+
+    fn load_acp_configs(
+        scope: threadlane_coding_agent::AcpScope,
+        global_dir: Option<&Path>,
+        work_dir: Option<&Path>,
+    ) -> Vec<threadlane_coding_agent::AcpAgentConfig> {
+        match scope {
+            threadlane_coding_agent::AcpScope::Global => {
+                threadlane_coding_agent::AcpSettings::load_global(global_dir)
+            }
+            threadlane_coding_agent::AcpScope::Project => {
+                threadlane_coding_agent::AcpSettings::load_project(work_dir)
+            }
+        }
+    }
+
+    fn save_acp_configs(
+        scope: threadlane_coding_agent::AcpScope,
+        global_dir: Option<&Path>,
+        work_dir: Option<&Path>,
+        configs: &[threadlane_coding_agent::AcpAgentConfig],
+    ) -> Result<(), String> {
+        match scope {
+            threadlane_coding_agent::AcpScope::Global => {
+                let dir = global_dir
+                    .ok_or_else(|| "No global Threadlane directory is available.".to_string())?;
+                threadlane_coding_agent::AcpSettings::save_global(dir, configs)
+            }
+            threadlane_coding_agent::AcpScope::Project => {
+                let root = work_dir.ok_or_else(|| {
+                    "Attach a project to manage project-scoped ACP agents.".to_string()
+                })?;
+                threadlane_coding_agent::AcpSettings::save_project(root, configs)
+            }
+        }
+    }
+
+    /// Probing an agent spawns its process, so refreshes run off the UI thread
+    /// and report back through `AcpRefreshCompleted`.
+    ///
+    /// Configured agents are rendered immediately from disk so the list is not
+    /// blank while a slow or missing agent binary is being probed.
+    fn refresh_acp_state(&mut self, cx: &mut Cx) {
+        let global_dir = threadlane_coding_agent::default_global_threadlane_dir();
+        let work_dir = self.active_work_dir().map(Path::to_path_buf);
+
+        let pending = threadlane_coding_agent::AcpManager::new(global_dir.clone(), work_dir.clone())
+            .configs()
+            .into_iter()
+            .map(|config| {
+                let status = if config.enabled {
+                    threadlane_coding_agent::AcpAgentStatus::Connecting
+                } else {
+                    threadlane_coding_agent::AcpAgentStatus::Disconnected
+                };
+                threadlane_coding_agent::AcpAgentRecord { config, status }
+            })
+            .collect();
+        self.capability_state.refresh_acp_records(pending);
+        if let Some(mut modal) = self
+            .ui
+            .widget(cx, ids!(providers_modal))
+            .borrow_mut::<ProviderSettingsModal>()
+        {
+            modal.set_acp_rows(cx, self.capability_state.acp_agents.clone());
+        }
+
+        if let Some(tx) = self.tx.clone() {
+            get_runtime().spawn(async move {
+                let records = threadlane_coding_agent::AcpManager::new(global_dir, work_dir)
+                    .discover_and_connect()
+                    .await;
+                let _ = tx.send(GuiAgentEvent::AcpRefreshCompleted(records));
+                SignalToUI::set_ui_signal();
+            });
+        }
+    }
+
+    fn set_acp_enabled(&mut self, cx: &mut Cx, row: usize, enabled: bool) {
+        let Some(selected) = self.capability_state.acp_agents.get(row).cloned() else {
+            self.refresh_acp_state(cx);
+            self.set_acp_status(cx, "ACP agent list changed. Please try again.");
+            return;
+        };
+        let global_dir = threadlane_coding_agent::default_global_threadlane_dir();
+        let work_dir = self.active_work_dir().map(Path::to_path_buf);
+        let mut configs =
+            Self::load_acp_configs(selected.scope, global_dir.as_deref(), work_dir.as_deref());
+        let Some(config) = configs.iter_mut().find(|c| c.id == selected.id) else {
+            self.refresh_acp_state(cx);
+            self.set_acp_status(cx, "ACP agent list changed. Please try again.");
+            return;
+        };
+        config.enabled = enabled;
+        if let Err(error) = Self::save_acp_configs(
+            selected.scope,
+            global_dir.as_deref(),
+            work_dir.as_deref(),
+            &configs,
+        ) {
+            self.set_acp_status(cx, &format!("Failed to save ACP agent: {error}"));
+            return;
+        }
+        self.set_acp_status(cx, "");
+        self.refresh_acp_state(cx);
+    }
+
+    fn remove_acp_agent(&mut self, cx: &mut Cx, row: usize) {
+        let Some(selected) = self.capability_state.acp_agents.get(row).cloned() else {
+            self.refresh_acp_state(cx);
+            self.set_acp_status(cx, "ACP agent list changed. Please try again.");
+            return;
+        };
+        let global_dir = threadlane_coding_agent::default_global_threadlane_dir();
+        let work_dir = self.active_work_dir().map(Path::to_path_buf);
+        let mut configs =
+            Self::load_acp_configs(selected.scope, global_dir.as_deref(), work_dir.as_deref());
+        configs.retain(|c| c.id != selected.id);
+        if let Err(error) = Self::save_acp_configs(
+            selected.scope,
+            global_dir.as_deref(),
+            work_dir.as_deref(),
+            &configs,
+        ) {
+            self.set_acp_status(cx, &format!("Failed to remove ACP agent: {error}"));
+            return;
+        }
+        self.set_acp_status(cx, &format!("Removed ACP agent '{}'.", selected.name));
+        self.refresh_acp_state(cx);
+    }
+
+    fn add_acp_agent(
+        &mut self,
+        cx: &mut Cx,
+        scope: threadlane_coding_agent::AcpScope,
+        name: String,
+        command: String,
+    ) {
+        let Some(new_config) =
+            threadlane_coding_agent::AcpAgentConfig::from_command_line(&name, &command, scope)
+        else {
+            self.set_acp_status(cx, "Please provide both an agent name and a command.");
+            return;
+        };
+        // ACP has no HTTP transport; an agent is always a local command.
+        if command.trim().starts_with("http://") || command.trim().starts_with("https://") {
+            self.set_acp_status(
+                cx,
+                "ACP agents are launched over stdio; provide a command, not a URL.",
+            );
+            return;
+        }
+
+        let global_dir = threadlane_coding_agent::default_global_threadlane_dir();
+        let work_dir = self.active_work_dir().map(Path::to_path_buf);
+        if scope == threadlane_coding_agent::AcpScope::Project && work_dir.is_none() {
+            self.set_acp_status(cx, "Attach a project to add project-scoped ACP agents.");
+            return;
+        }
+
+        let mut configs = Self::load_acp_configs(scope, global_dir.as_deref(), work_dir.as_deref());
+        configs.retain(|c| c.id != new_config.id);
+        let display_name = new_config.name.clone();
+        configs.push(new_config);
+
+        match Self::save_acp_configs(scope, global_dir.as_deref(), work_dir.as_deref(), &configs) {
+            Ok(()) => {
+                self.set_acp_status(cx, &format!("Added ACP agent '{display_name}'."));
+                self.refresh_acp_state(cx);
+            }
+            Err(error) => {
+                self.set_acp_status(cx, &format!("Failed to save ACP agent: {error}"));
+            }
+        }
+    }
+
     fn set_skill_status(&mut self, cx: &mut Cx, status: &str) {
         if let Some(mut modal) = self
             .ui
@@ -7931,6 +8283,16 @@ impl App {
                     {
                         modal.set_mcp_rows(cx, self.capability_state.mcp_servers.clone());
                         modal.set_mcp_status(cx, "");
+                    }
+                }
+                GuiAgentEvent::AcpRefreshCompleted(records) => {
+                    self.capability_state.refresh_acp_records(records);
+                    if let Some(mut modal) = self
+                        .ui
+                        .widget(cx, ids!(providers_modal))
+                        .borrow_mut::<ProviderSettingsModal>()
+                    {
+                        modal.set_acp_rows(cx, self.capability_state.acp_agents.clone());
                     }
                 }
                 GuiAgentEvent::BackgroundTask(event) => {

--- a/crates/threadlane/src/app/settings_handlers.rs
+++ b/crates/threadlane/src/app/settings_handlers.rs
@@ -40,6 +40,21 @@ impl App {
                 } => {
                     self.add_mcp_server(cx, scope, name, command);
                 }
+                ProviderSettingsModalAction::ShowAcpAgents
+                | ProviderSettingsModalAction::RefreshAcpAgents => self.refresh_acp_state(cx),
+                ProviderSettingsModalAction::SetAcpEnabled { row, enabled } => {
+                    self.set_acp_enabled(cx, row, enabled);
+                }
+                ProviderSettingsModalAction::RemoveAcpAgent(row) => {
+                    self.remove_acp_agent(cx, row);
+                }
+                ProviderSettingsModalAction::AddAcpAgent {
+                    scope,
+                    name,
+                    command,
+                } => {
+                    self.add_acp_agent(cx, scope, name, command);
+                }
                 ProviderSettingsModalAction::None => {}
             }
         }

--- a/crates/threadlane/src/components/provider_settings_modal.rs
+++ b/crates/threadlane/src/components/provider_settings_modal.rs
@@ -11,6 +11,7 @@ pub enum SettingsPage {
     Capabilities,
     Skills,
     McpServers,
+    AcpAgents,
     About,
 }
 
@@ -42,6 +43,18 @@ pub enum ProviderSettingsModalAction {
         name: String,
         command: String,
     },
+    ShowAcpAgents,
+    SetAcpEnabled {
+        row: usize,
+        enabled: bool,
+    },
+    RemoveAcpAgent(usize),
+    RefreshAcpAgents,
+    AddAcpAgent {
+        scope: threadlane_coding_agent::AcpScope,
+        name: String,
+        command: String,
+    },
     #[default]
     None,
 }
@@ -66,6 +79,8 @@ pub struct ProviderSettingsModal {
     skill_rows: Vec<crate::state::CapabilitySkillRow>,
     #[rust]
     mcp_rows: Vec<crate::state::CapabilityMcpRow>,
+    #[rust]
+    acp_rows: Vec<crate::state::CapabilityAcpRow>,
     #[rust]
     install_scope_global: bool,
 }
@@ -144,6 +159,14 @@ impl Widget for ProviderSettingsModal {
             }
             if self
                 .view
+                .button(cx, ids!(settings_nav_acp_btn))
+                .clicked(actions)
+            {
+                self.set_page(cx, SettingsPage::AcpAgents);
+                cx.widget_action(uid, ProviderSettingsModalAction::ShowAcpAgents);
+            }
+            if self
+                .view
                 .button(cx, ids!(settings_nav_about_btn))
                 .clicked(actions)
             {
@@ -165,6 +188,10 @@ impl Widget for ProviderSettingsModal {
                     .view
                     .button(cx, ids!(mcp_scope_project_btn))
                     .clicked(actions)
+                || self
+                    .view
+                    .button(cx, ids!(acp_scope_project_btn))
+                    .clicked(actions)
             {
                 self.install_scope_global = false;
                 self.sync_install_scope(cx);
@@ -173,6 +200,10 @@ impl Widget for ProviderSettingsModal {
                 .view
                 .button(cx, ids!(mcp_scope_global_btn))
                 .clicked(actions)
+                || self
+                    .view
+                    .button(cx, ids!(acp_scope_global_btn))
+                    .clicked(actions)
             {
                 self.install_scope_global = true;
                 self.sync_install_scope(cx);
@@ -192,6 +223,27 @@ impl Widget for ProviderSettingsModal {
                 cx.widget_action(
                     uid,
                     ProviderSettingsModalAction::AddMcpServer {
+                        scope,
+                        name,
+                        command,
+                    },
+                );
+            }
+            if self
+                .view
+                .button(cx, ids!(acp_submit_add_btn))
+                .clicked(actions)
+            {
+                let name = self.view.text_input(cx, ids!(acp_name_input)).text();
+                let command = self.view.text_input(cx, ids!(acp_command_input)).text();
+                let scope = if self.install_scope_global {
+                    threadlane_coding_agent::AcpScope::Global
+                } else {
+                    threadlane_coding_agent::AcpScope::Project
+                };
+                cx.widget_action(
+                    uid,
+                    ProviderSettingsModalAction::AddAcpAgent {
                         scope,
                         name,
                         command,
@@ -221,6 +273,9 @@ impl Widget for ProviderSettingsModal {
             }
             if self.view.button(cx, ids!(mcp_refresh_btn)).clicked(actions) {
                 cx.widget_action(uid, ProviderSettingsModalAction::RefreshMcpServers);
+            }
+            if self.view.button(cx, ids!(acp_refresh_btn)).clicked(actions) {
+                cx.widget_action(uid, ProviderSettingsModalAction::RefreshAcpAgents);
             }
             let list = self.view.portal_list(cx, ids!(capability_list));
             for (row, item) in list.items_with_actions(actions) {
@@ -253,6 +308,18 @@ impl Widget for ProviderSettingsModal {
                 }
                 if item.button(cx, ids!(remove_btn)).clicked(actions) {
                     cx.widget_action(uid, ProviderSettingsModalAction::RemoveMcpServer(row));
+                }
+            }
+            let acp_list = self.view.portal_list(cx, ids!(acp_list));
+            for (row, item) in acp_list.items_with_actions(actions) {
+                if let Some(enabled) = item.check_box(cx, ids!(enabled_toggle)).changed(actions) {
+                    cx.widget_action(
+                        uid,
+                        ProviderSettingsModalAction::SetAcpEnabled { row, enabled },
+                    );
+                }
+                if item.button(cx, ids!(remove_btn)).clicked(actions) {
+                    cx.widget_action(uid, ProviderSettingsModalAction::RemoveAcpAgent(row));
                 }
             }
         }
@@ -334,6 +401,32 @@ impl Widget for ProviderSettingsModal {
                             );
                             item.draw_all_unscoped(cx);
                         }
+                    } else if self.page == SettingsPage::AcpAgents {
+                        list.set_item_range(cx, 0, self.acp_rows.len().max(1));
+                        while let Some(row_index) = list.next_visible_item(cx) {
+                            if self.acp_rows.is_empty() {
+                                if row_index == 0 {
+                                    list.item(cx, row_index, id!(AcpEmptyRow))
+                                        .draw_all_unscoped(cx);
+                                }
+                                continue;
+                            }
+                            let Some(row) = self.acp_rows.get(row_index) else {
+                                continue;
+                            };
+                            let item = list.item(cx, row_index, id!(AcpRow));
+                            item.label(cx, ids!(name_lbl)).set_text(cx, &row.name);
+                            item.label(cx, ids!(scope_lbl))
+                                .set_text(cx, &row.scope_status());
+                            item.label(cx, ids!(path_lbl))
+                                .set_text(cx, &row.command_detail);
+                            item.check_box(cx, ids!(enabled_toggle)).set_active(
+                                cx,
+                                row.enabled,
+                                Animate::No,
+                            );
+                            item.draw_all_unscoped(cx);
+                        }
                     } else if self.page == SettingsPage::Capabilities {
                         list.set_item_range(cx, 0, self.extension_rows.len().max(1));
                         while let Some(row_index) = list.next_visible_item(cx) {
@@ -402,6 +495,17 @@ impl ProviderSettingsModal {
         self.redraw_capability_overlay(cx);
     }
 
+    pub fn set_acp_rows(&mut self, cx: &mut Cx, rows: Vec<crate::state::CapabilityAcpRow>) {
+        self.acp_rows = rows;
+        self.redraw_capability_overlay(cx);
+    }
+
+    pub fn set_acp_status(&mut self, cx: &mut Cx, status: &str) {
+        self.view
+            .label(cx, ids!(acp_status_lbl))
+            .set_text(cx, status);
+    }
+
     pub fn set_mcp_status(&mut self, cx: &mut Cx, status: &str) {
         self.view
             .label(cx, ids!(mcp_status_lbl))
@@ -453,6 +557,8 @@ impl ProviderSettingsModal {
             ),
             (ids!(mcp_scope_global_btn), self.install_scope_global),
             (ids!(mcp_scope_project_btn), !self.install_scope_global),
+            (ids!(acp_scope_global_btn), self.install_scope_global),
+            (ids!(acp_scope_project_btn), !self.install_scope_global),
         ] {
             let mut button = self.view.button(cx, button_id);
             let color = if selected {
@@ -487,6 +593,7 @@ impl ProviderSettingsModal {
         let capabilities_selected = self.page == SettingsPage::Capabilities;
         let skills_selected = self.page == SettingsPage::Skills;
         let mcp_selected = self.page == SettingsPage::McpServers;
+        let acp_selected = self.page == SettingsPage::AcpAgents;
         let about_selected = self.page == SettingsPage::About;
 
         for (button_id, selected) in [
@@ -495,6 +602,7 @@ impl ProviderSettingsModal {
             (ids!(settings_nav_capabilities_btn), capabilities_selected),
             (ids!(settings_nav_skills_btn), skills_selected),
             (ids!(settings_nav_mcp_btn), mcp_selected),
+            (ids!(settings_nav_acp_btn), acp_selected),
             (ids!(settings_nav_about_btn), about_selected),
         ] {
             let button = self.view.button(cx, button_id);
@@ -518,6 +626,9 @@ impl ProviderSettingsModal {
             .button(cx, ids!(settings_nav_mcp_btn))
             .set_visible(cx, true);
         self.view
+            .button(cx, ids!(settings_nav_acp_btn))
+            .set_visible(cx, true);
+        self.view
             .button(cx, ids!(settings_nav_about_btn))
             .set_visible(cx, true);
         self.view
@@ -535,6 +646,9 @@ impl ProviderSettingsModal {
         self.view
             .widget(cx, ids!(mcp_page))
             .set_visible(cx, mcp_selected);
+        self.view
+            .widget(cx, ids!(acp_page))
+            .set_visible(cx, acp_selected);
         self.view
             .widget(cx, ids!(about_page))
             .set_visible(cx, about_selected);

--- a/crates/threadlane/src/panels/settings/view.rs
+++ b/crates/threadlane/src/panels/settings/view.rs
@@ -9,6 +9,7 @@ pub enum SettingsTab {
     WasiExtensions,
     Skills,
     McpServers,
+    AcpAgents,
     About,
 }
 
@@ -21,6 +22,7 @@ impl SettingsTab {
             Self::WasiExtensions => "WASI Extensions",
             Self::Skills => "Skills",
             Self::McpServers => "MCP Servers",
+            Self::AcpAgents => "ACP Agents",
             Self::About => "About",
         }
     }

--- a/crates/threadlane/src/state.rs
+++ b/crates/threadlane/src/state.rs
@@ -94,11 +94,32 @@ impl CapabilityMcpRow {
     }
 }
 
+#[derive(Clone)]
+pub struct CapabilityAcpRow {
+    pub id: String,
+    pub name: String,
+    pub command_detail: String,
+    pub scope: threadlane_coding_agent::AcpScope,
+    pub enabled: bool,
+    pub status_text: String,
+}
+
+impl CapabilityAcpRow {
+    pub fn scope_status(&self) -> String {
+        let scope = match self.scope {
+            threadlane_coding_agent::AcpScope::Global => "Global",
+            threadlane_coding_agent::AcpScope::Project => "Project",
+        };
+        format!("{scope} · {}", self.status_text)
+    }
+}
+
 #[derive(Default)]
 pub struct CapabilityState {
     pub extensions: Vec<CapabilityExtensionRow>,
     pub skills: Vec<CapabilitySkillRow>,
     pub mcp_servers: Vec<CapabilityMcpRow>,
+    pub acp_agents: Vec<CapabilityAcpRow>,
 }
 
 impl CapabilityState {
@@ -143,6 +164,20 @@ impl CapabilityState {
                     enabled: rec.config.enabled,
                     status_text: rec.status.display_status(),
                 }
+            })
+            .collect();
+    }
+
+    pub fn refresh_acp_records(&mut self, records: Vec<threadlane_coding_agent::AcpAgentRecord>) {
+        self.acp_agents = records
+            .into_iter()
+            .map(|rec| CapabilityAcpRow {
+                command_detail: rec.config.command_line(),
+                id: rec.config.id,
+                name: rec.config.name,
+                scope: rec.config.scope,
+                enabled: rec.config.enabled,
+                status_text: rec.status.display_status(),
             })
             .collect();
     }
@@ -229,6 +264,7 @@ pub enum GuiAgentEvent {
         result: Result<String, String>,
     },
     McpRefreshCompleted(Vec<threadlane_coding_agent::McpServerRecord>),
+    AcpRefreshCompleted(Vec<threadlane_coding_agent::AcpAgentRecord>),
 }
 
 #[cfg(test)]


### PR DESCRIPTION
> **Stacked on #33.** This branch contains that commit as its parent, so the diff below currently shows both. Once #33 merges, GitHub narrows this PR to the single UI commit. Review #33 first.

Wires the ACP client from #33 into the settings modal so external agents can be configured without hand-editing JSON.

## What's here

A new **ACP Agents** settings page listing agents from `~/.threadlane/acp.json` and `<project>/.threadlane/acp.json`:

- Add an agent by name and command, at Global or Project scope
- Enable, disable, and remove per scope
- Refresh launches each enabled agent, completes the ACP handshake, and reports the agent name, negotiated protocol version, and whether sign-in is still required; a failed launch shows its error in place, so a missing binary or wrong command is visible without leaving the page

## Design notes for review

**Mirrors the MCP Servers page** rather than introducing new patterns: same `CapabilityRowWithRemove` rows, same empty-row template, same status label, and the modal's existing `install_scope_global` flag for scope selection instead of a parallel scope state.

**Probing spawns processes**, so it runs off the UI thread and reports back through a new `GuiAgentEvent::AcpRefreshCompleted`. Two consequences worth checking:

- `refresh_acp_state` renders configured agents from disk immediately with a `Connecting` status, then replaces them when the probe completes. Without this the list sits blank while a slow or missing binary works through its handshake timeout.
- Opening the settings modal does **not** probe. `open_capabilities_modal` is deliberately untouched, so merely opening settings never launches third-party binaries — probing starts only when the ACP page is selected or refreshed.

**Scope validation** happens before any write: project scope with no attached project, and blank name or command, both report in the status label rather than failing silently. Saving reports a real error instead of unwrapping a missing global directory.

## Testing

`cargo check -p threadlane` and `cargo test --workspace` pass. `git diff --check` is clean. The app launches cleanly with the new page registered and its widget ids resolving at startup.

**Not verified:** the rendered page has not been clicked through in a running window, so the layout of the new `acp_page` and its row list still deserve a visual pass. `README.md` documents the page and the config file; `AGENTS.md` records the settings-modal conventions this relies on.