### PR TITLE
perf: reuse MCP server sessions and parse session files once

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -315,6 +315,14 @@ If changing ordering, row height, popup padding, or selected-item behavior, upda
 - Editor file loading refuses directories, non-UTF-8 content, and files over `MAX_EDITABLE_BYTES`. Keep that policy in `load_editable_text` rather than at the call site so it stays testable without a `Cx`.
 - Saving writes `Text`'s `Display` form. It round-trips byte-for-byte, so do not "normalize" line endings on save; a covering test guards this.
 
+## Performance
+
+- Measure before changing. `crates/threadlane-mcp/tests/perf_baseline.rs` and `crates/threadlane-agent/tests/perf_baseline.rs` are `#[ignore]`d measurement harnesses, not assertions; run them with `-- --ignored --nocapture` to get a baseline and again to prove a change helped. Do not optimize a path whose cost has not been measured.
+- Pin a performance fix with a *behavioral* test, not a timing one. `tests/session_reuse.rs` counts how many server processes actually start, so it fails for the right reason on a loaded CI machine.
+- MCP servers are long-lived: `McpManager` keeps one `McpSession` per server id and reuses it across tool calls. Do not reintroduce spawn-per-call — it cost ~5 ms per call against a trivial shell stub and far more against a real `npx`-based server. A failed exchange retires the session so the next call reconnects, and `Command::kill_on_drop` cleans up when the manager drops.
+- Each MCP session carries its own lock. Hold the session map only long enough to look up or install a handle, never across the request round trip, or tool calls to unrelated servers serialize behind each other.
+- Session files are parsed once through the untagged `SessionLine` enum. Do not go back to trying `SessionRecord` and then `SessionNode`, which parsed the JSON text of every node line twice.
+
 ## Updater Behavior
 
 - `THREADLANE_UPDATER_PUBLIC_KEY` and `THREADLANE_UPDATER_ENDPOINT` are compile-time environment values through `option_env!`.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3538,6 +3538,7 @@ dependencies = [
  "futures",
  "serde",
  "serde_json",
+ "tempfile",
  "threadlane-agent",
  "tokio",
 ]

--- a/crates/threadlane-agent/src/session_tree.rs
+++ b/crates/threadlane-agent/src/session_tree.rs
@@ -65,6 +65,22 @@ pub struct SessionNode {
     pub message: AgentMessage,
 }
 
+/// One line of a session file.
+///
+/// Loading previously tried `SessionRecord` and then `SessionNode`, which
+/// parsed the JSON *text* of every node line twice — and node lines are the
+/// overwhelming majority. `untagged` buffers the parse once and matches the
+/// variants against that buffer instead.
+///
+/// Order matters: `SessionRecord` is internally tagged and cannot match a node
+/// line, which carries no `type`.
+#[derive(Debug, Deserialize)]
+#[serde(untagged)]
+enum SessionLine {
+    Record(SessionRecord),
+    Node(SessionNode),
+}
+
 #[derive(Debug, Serialize, Deserialize)]
 #[serde(tag = "type")]
 enum SessionRecord {
@@ -642,8 +658,8 @@ impl SessionTree {
             if l.trim().is_empty() {
                 continue;
             }
-            if let Ok(record) = serde_json::from_str::<SessionRecord>(&l) {
-                match record {
+            match serde_json::from_str::<SessionLine>(&l) {
+                Ok(SessionLine::Record(record)) => match record {
                     SessionRecord::Metadata {
                         name,
                         title_attempted,
@@ -665,13 +681,15 @@ impl SessionTree {
                     SessionRecord::GlobalFact { key, value } => {
                         tree.global_facts.insert(key, value);
                     }
+                },
+                Ok(SessionLine::Node(node)) => {
+                    if !explicit_active {
+                        tree.active_node_id = Some(node.id.clone());
+                    }
+                    tree.node_order.push(node.id.clone());
+                    tree.nodes.insert(node.id.clone(), node);
                 }
-            } else if let Ok(node) = serde_json::from_str::<SessionNode>(&l) {
-                if !explicit_active {
-                    tree.active_node_id = Some(node.id.clone());
-                }
-                tree.node_order.push(node.id.clone());
-                tree.nodes.insert(node.id.clone(), node);
+                Err(_) => {}
             }
         }
 

--- a/crates/threadlane-agent/tests/perf_baseline.rs
+++ b/crates/threadlane-agent/tests/perf_baseline.rs
@@ -1,0 +1,63 @@
+//! Measurement harness for session-tree hot paths.
+//!
+//! Ignored by default: reports timings rather than asserting behavior. Run with
+//! `cargo test -p threadlane-agent --test perf_baseline -- --ignored --nocapture`.
+
+use std::time::Instant;
+use threadlane_agent::session_tree::SessionTree;
+use threadlane_agent::types::AgentMessage;
+
+fn build_session(nodes: usize) -> (tempfile::TempDir, std::path::PathBuf) {
+    let dir = tempfile::tempdir().unwrap();
+    let path = dir.path().join("session.jsonl");
+    let mut tree = SessionTree::new("bench".to_string());
+    // `add_message` persists through the tree's own file path, which is the
+    // same write path a live session uses.
+    tree.file_path = Some(path.clone());
+
+    for index in 0..nodes {
+        let message = if index % 2 == 0 {
+            AgentMessage::user(
+                format!("user turn {index} with some representative length"),
+                Vec::new(),
+            )
+        } else {
+            AgentMessage::Assistant {
+                content: Some(format!(
+                    "assistant turn {index} with a longer body, roughly the size of a short \
+                     reply that a model would stream back over a few seconds of generation"
+                )),
+                tool_calls: None,
+                stop_reason: None,
+                deferred_handle: None,
+            }
+        };
+        tree.add_message(message);
+    }
+    (dir, path)
+}
+
+#[test]
+#[ignore = "measurement harness, not an assertion"]
+fn session_tree_load_and_branch_walk() {
+    for nodes in [200usize, 1000, 4000] {
+        let (_dir, path) = build_session(nodes);
+        let bytes = std::fs::metadata(&path).unwrap().len();
+
+        let load_start = Instant::now();
+        let tree = SessionTree::load_from_file(&path).unwrap();
+        let load = load_start.elapsed();
+
+        let branch_start = Instant::now();
+        let branch = tree.get_active_branch_messages();
+        let branch_time = branch_start.elapsed();
+
+        println!(
+            "nodes={nodes:<5} file={:>7}KB  load={:>10?}  active_branch={:>10?}  branch_len={}",
+            bytes / 1024,
+            load,
+            branch_time,
+            branch.len()
+        );
+    }
+}

--- a/crates/threadlane-mcp/Cargo.toml
+++ b/crates/threadlane-mcp/Cargo.toml
@@ -11,3 +11,6 @@ serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 async-trait = "0.1"
 futures = "0.3"
+
+[dev-dependencies]
+tempfile = "3.10"

--- a/crates/threadlane-mcp/src/lib.rs
+++ b/crates/threadlane-mcp/src/lib.rs
@@ -10,12 +10,13 @@ use std::sync::{Arc, RwLock};
 use std::time::Duration;
 use threadlane_agent::{AgentToolDefinition, ToolExecutor};
 use tokio::io::{AsyncBufReadExt, AsyncWriteExt, BufReader};
-use tokio::process::Command;
+use tokio::process::{Child, ChildStdin, ChildStdout, Command};
 use tokio::sync::Mutex as TokioMutex;
 
 const MCP_SETTINGS_FILE: &str = "mcp.json";
 const MCP_PROJECT_SETTINGS_RELATIVE_PATH: &str = ".threadlane/mcp.json";
 const MAX_MCP_SETTINGS_BYTES: usize = 512 * 1024;
+const MCP_REQUEST_TIMEOUT: Duration = Duration::from_secs(15);
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, Default)]
 #[serde(rename_all = "snake_case")]
@@ -170,11 +171,148 @@ pub struct McpServerRecord {
     pub tools: Vec<McpToolInfo>,
 }
 
+/// A live stdio session with one MCP server.
+///
+/// The handshake is performed once when the process starts and the pipes stay
+/// open, so a tool call costs one request/response round trip instead of a
+/// process spawn plus a full `initialize` exchange.
+struct McpSession {
+    child: Child,
+    stdin: ChildStdin,
+    reader: BufReader<ChildStdout>,
+    next_id: u64,
+}
+
+impl McpSession {
+    /// Spawns the server and completes the MCP handshake.
+    async fn connect(config: &McpServerConfig) -> Result<Self, String> {
+        let McpTransport::Stdio { command, args, env } = &config.transport else {
+            return Err("Only stdio MCP servers can be connected".to_string());
+        };
+
+        let mut cmd = Command::new(command);
+        cmd.args(args);
+        for (key, value) in env {
+            cmd.env(key, value);
+        }
+        cmd.stdin(Stdio::piped())
+            .stdout(Stdio::piped())
+            .stderr(Stdio::null())
+            // Without this a crashed or replaced session leaks its process.
+            .kill_on_drop(true);
+
+        let mut child = cmd
+            .spawn()
+            .map_err(|error| format!("Failed to spawn process: {error}"))?;
+        let stdin = child
+            .stdin
+            .take()
+            .ok_or_else(|| "Failed to open stdin".to_string())?;
+        let stdout = child
+            .stdout
+            .take()
+            .ok_or_else(|| "Failed to open stdout".to_string())?;
+
+        let mut session = Self {
+            child,
+            stdin,
+            reader: BufReader::new(stdout),
+            next_id: 1,
+        };
+
+        session
+            .request(
+                "initialize",
+                json!({
+                    "protocolVersion": "2024-11-05",
+                    "capabilities": {},
+                    "clientInfo": { "name": "threadlane", "version": env!("CARGO_PKG_VERSION") }
+                }),
+            )
+            .await
+            .map_err(|error| format!("Initialize failed: {error}"))?;
+        session
+            .notify("notifications/initialized", Value::Null)
+            .await?;
+        Ok(session)
+    }
+
+    async fn write_line(&mut self, message: &Value) -> Result<(), String> {
+        let mut line = message.to_string();
+        line.push('\n');
+        self.stdin
+            .write_all(line.as_bytes())
+            .await
+            .map_err(|error| format!("Failed to write to MCP server: {error}"))?;
+        self.stdin
+            .flush()
+            .await
+            .map_err(|error| format!("Failed to flush MCP server stdin: {error}"))
+    }
+
+    async fn notify(&mut self, method: &str, params: Value) -> Result<(), String> {
+        self.write_line(&json!({ "jsonrpc": "2.0", "method": method, "params": params }))
+            .await
+    }
+
+    /// Sends a request and reads until the matching response arrives.
+    ///
+    /// Notifications and unrelated responses are skipped rather than mistaken
+    /// for the answer, which a single blind `read_line` would do.
+    async fn request(&mut self, method: &str, params: Value) -> Result<Value, String> {
+        let id = self.next_id;
+        self.next_id += 1;
+        self.write_line(&json!({
+            "jsonrpc": "2.0",
+            "id": id,
+            "method": method,
+            "params": params,
+        }))
+        .await?;
+
+        let deadline = tokio::time::Instant::now() + MCP_REQUEST_TIMEOUT;
+        loop {
+            let mut line = String::new();
+            let read = tokio::time::timeout_at(deadline, self.reader.read_line(&mut line))
+                .await
+                .map_err(|_| format!("MCP request '{method}' timed out"))?
+                .map_err(|error| format!("Failed to read from MCP server: {error}"))?;
+            if read == 0 {
+                return Err("MCP server closed its output stream".to_string());
+            }
+            let Ok(message) = serde_json::from_str::<Value>(line.trim()) else {
+                continue;
+            };
+            if message.get("id").and_then(Value::as_u64) != Some(id) {
+                continue;
+            }
+            if let Some(error) = message.get("error") {
+                let text = error
+                    .get("message")
+                    .and_then(Value::as_str)
+                    .unwrap_or("MCP error");
+                return Err(text.to_string());
+            }
+            return Ok(message.get("result").cloned().unwrap_or(Value::Null));
+        }
+    }
+
+    async fn shutdown(mut self) {
+        let _ = self.child.kill().await;
+    }
+}
+
 pub struct McpManager {
     global_dir: Option<PathBuf>,
     project_root: Option<PathBuf>,
     servers: TokioMutex<Vec<McpServerRecord>>,
     cached_tool_defs: RwLock<Vec<AgentToolDefinition>>,
+    /// Live sessions keyed by server id, reused across tool calls.
+    ///
+    /// Each session carries its own lock so a call to one server never blocks a
+    /// call to another; the outer map is held only long enough to look up or
+    /// install the handle, never across the request round trip.
+    sessions: TokioMutex<HashMap<String, Arc<TokioMutex<McpSession>>>>,
 }
 
 impl McpManager {
@@ -184,6 +322,20 @@ impl McpManager {
             project_root,
             servers: TokioMutex::new(Vec::new()),
             cached_tool_defs: RwLock::new(Vec::new()),
+            sessions: TokioMutex::new(HashMap::new()),
+        }
+    }
+
+    /// Terminates every live server session.
+    ///
+    /// Call when the manager's project changes or the app shuts down; sessions
+    /// otherwise live as long as the manager does.
+    pub async fn shutdown(&self) {
+        let sessions = std::mem::take(&mut *self.sessions.lock().await);
+        for (_, session) in sessions {
+            if let Ok(session) = Arc::try_unwrap(session) {
+                session.into_inner().shutdown().await;
+            }
         }
     }
 
@@ -213,7 +365,7 @@ impl McpManager {
                 continue;
             }
 
-            let (status, tools) = Self::connect_server(&config).await;
+            let (status, tools) = self.connect_server(&config).await;
             for t in &tools {
                 tool_defs.push(t.definition.clone());
             }
@@ -232,165 +384,74 @@ impl McpManager {
         records
     }
 
-    async fn connect_server(config: &McpServerConfig) -> (McpServerStatus, Vec<McpToolInfo>) {
-        match &config.transport {
-            McpTransport::Stdio { command, args, env } => {
-                let mut cmd = Command::new(command);
-                cmd.args(args);
-                for (k, v) in env {
-                    cmd.env(k, v);
-                }
-                cmd.stdin(Stdio::piped())
-                    .stdout(Stdio::piped())
-                    .stderr(Stdio::null());
-
-                let mut child = match cmd.spawn() {
-                    Ok(c) => c,
-                    Err(e) => {
-                        return (
-                            McpServerStatus::Error(format!("Failed to spawn process: {e}")),
-                            Vec::new(),
-                        )
-                    }
-                };
-
-                let mut stdin = match child.stdin.take() {
-                    Some(s) => s,
-                    None => {
-                        return (
-                            McpServerStatus::Error("Failed to open stdin".into()),
-                            Vec::new(),
-                        )
-                    }
-                };
-                let stdout = match child.stdout.take() {
-                    Some(s) => s,
-                    None => {
-                        return (
-                            McpServerStatus::Error("Failed to open stdout".into()),
-                            Vec::new(),
-                        )
-                    }
-                };
-
-                let mut reader = BufReader::new(stdout);
-
-                // Send initialize JSON-RPC request
-                let init_req = json!({
-                    "jsonrpc": "2.0",
-                    "id": 1,
-                    "method": "initialize",
-                    "params": {
-                        "protocolVersion": "2024-11-05",
-                        "capabilities": {},
-                        "clientInfo": {
-                            "name": "threadlane",
-                            "version": env!("CARGO_PKG_VERSION")
-                        }
-                    }
-                });
-
-                let mut line = String::new();
-                let write_res = stdin.write_all(format!("{}\n", init_req).as_bytes()).await;
-                if let Err(e) = write_res {
-                    let _ = child.kill().await;
-                    return (
-                        McpServerStatus::Error(format!("Failed to send initialize: {e}")),
-                        Vec::new(),
-                    );
-                }
-
-                let read_res =
-                    tokio::time::timeout(Duration::from_secs(5), reader.read_line(&mut line)).await;
-                if read_res.is_err() || line.trim().is_empty() {
-                    let _ = child.kill().await;
-                    return (
-                        McpServerStatus::Error("Initialize response timed out".into()),
-                        Vec::new(),
-                    );
-                }
-
-                // Send initialized notification
-                let init_notif = json!({
-                    "jsonrpc": "2.0",
-                    "method": "notifications/initialized"
-                });
-                let _ = stdin
-                    .write_all(format!("{}\n", init_notif).as_bytes())
-                    .await;
-
-                // Send tools/list request
-                let list_req = json!({
-                    "jsonrpc": "2.0",
-                    "id": 2,
-                    "method": "tools/list",
-                    "params": {}
-                });
-                let _ = stdin.write_all(format!("{}\n", list_req).as_bytes()).await;
-
-                line.clear();
-                let list_res =
-                    tokio::time::timeout(Duration::from_secs(5), reader.read_line(&mut line)).await;
-                let _ = child.kill().await;
-
-                if list_res.is_err() || line.trim().is_empty() {
-                    return (
-                        McpServerStatus::Error("tools/list response timed out".into()),
-                        Vec::new(),
-                    );
-                }
-
-                let response_json: Value = match serde_json::from_str(line.trim()) {
-                    Ok(val) => val,
-                    Err(e) => {
-                        return (
-                            McpServerStatus::Error(format!("Failed to parse response: {e}")),
-                            Vec::new(),
-                        )
-                    }
-                };
-
-                let mut mcp_tools = Vec::new();
-                if let Some(tools_arr) = response_json
-                    .get("result")
-                    .and_then(|r| r.get("tools"))
-                    .and_then(|t| t.as_array())
-                {
-                    for tool_val in tools_arr {
-                        if let Some(name) = tool_val.get("name").and_then(|n| n.as_str()) {
-                            let description = tool_val
-                                .get("description")
-                                .and_then(|d| d.as_str())
-                                .unwrap_or("MCP tool");
-                            let input_schema = tool_val
-                                .get("inputSchema")
-                                .cloned()
-                                .unwrap_or_else(|| json!({"type": "object", "properties": {}}));
-
-                            let full_name = format!("mcp__{}__{}", config.id, name);
-                            let definition = AgentToolDefinition::new(
-                                full_name.clone(),
-                                format!("[MCP: {}] {}", config.name, description),
-                                input_schema,
-                            );
-
-                            mcp_tools.push(McpToolInfo {
-                                tool_name: name.to_string(),
-                                full_name,
-                                definition,
-                            });
-                        }
-                    }
-                }
-
-                let count = mcp_tools.len();
-                (McpServerStatus::Connected { tool_count: count }, mcp_tools)
-            }
-            McpTransport::Sse { url, .. } => (
+    /// Opens (or reuses) a session and lists the server's tools.
+    async fn connect_server(&self, config: &McpServerConfig) -> (McpServerStatus, Vec<McpToolInfo>) {
+        if matches!(config.transport, McpTransport::Sse { .. }) {
+            let McpTransport::Sse { url, .. } = &config.transport else {
+                unreachable!("transport was just matched as SSE")
+            };
+            return (
                 McpServerStatus::Error(format!("SSE transport ({url}) not active")),
                 Vec::new(),
-            ),
+            );
         }
+
+        // A previous session may be stale after a config change, so discovery
+        // always starts a fresh one and retires the old process.
+        let previous = self.sessions.lock().await.remove(&config.id);
+        if let Some(previous) = previous {
+            if let Ok(previous) = Arc::try_unwrap(previous) {
+                previous.into_inner().shutdown().await;
+            }
+        }
+        let mut session = match McpSession::connect(config).await {
+            Ok(session) => session,
+            Err(error) => return (McpServerStatus::Error(error), Vec::new()),
+        };
+
+        let listed = session.request("tools/list", json!({})).await;
+        let response = match listed {
+            Ok(response) => response,
+            Err(error) => {
+                session.shutdown().await;
+                return (McpServerStatus::Error(error), Vec::new());
+            }
+        };
+
+        let mut mcp_tools = Vec::new();
+        if let Some(tools) = response.get("tools").and_then(Value::as_array) {
+            for tool in tools {
+                let Some(name) = tool.get("name").and_then(Value::as_str) else {
+                    continue;
+                };
+                let description = tool
+                    .get("description")
+                    .and_then(Value::as_str)
+                    .unwrap_or("MCP tool");
+                let input_schema = tool
+                    .get("inputSchema")
+                    .cloned()
+                    .unwrap_or_else(|| json!({"type": "object", "properties": {}}));
+                let full_name = format!("mcp__{}__{}", config.id, name);
+                mcp_tools.push(McpToolInfo {
+                    tool_name: name.to_string(),
+                    full_name: full_name.clone(),
+                    definition: AgentToolDefinition::new(
+                        full_name,
+                        format!("[MCP: {}] {}", config.name, description),
+                        input_schema,
+                    ),
+                });
+            }
+        }
+
+        // Keep the session for tool calls instead of killing it here.
+        self.sessions
+            .lock()
+            .await
+            .insert(config.id.clone(), Arc::new(TokioMutex::new(session)));
+        let count = mcp_tools.len();
+        (McpServerStatus::Connected { tool_count: count }, mcp_tools)
     }
 
     fn get_tools_sync(&self) -> Vec<AgentToolDefinition> {
@@ -401,135 +462,91 @@ impl McpManager {
     }
 
     async fn execute_tool(&self, full_name: &str, args: &str) -> Option<Result<String, String>> {
-        let guard = self.servers.lock().await;
-        let mut target = None;
-        for server in guard.iter() {
-            if !server.config.enabled {
-                continue;
-            }
-            for tool in &server.tools {
-                if tool.full_name == full_name || tool.tool_name == full_name {
-                    target = Some((server.config.clone(), tool.tool_name.clone()));
-                    break;
+        let target = {
+            let servers = self.servers.lock().await;
+            servers.iter().find_map(|server| {
+                if !server.config.enabled {
+                    return None;
                 }
-            }
-            if target.is_some() {
-                break;
-            }
-        }
-        drop(guard);
-
+                server
+                    .tools
+                    .iter()
+                    .find(|tool| tool.full_name == full_name || tool.tool_name == full_name)
+                    .map(|tool| (server.config.clone(), tool.tool_name.clone()))
+            })
+        };
         let (config, tool_name) = target?;
+
         let parsed_args: Value = match serde_json::from_str(args) {
-            Ok(v) => v,
-            Err(e) => return Some(Err(format!("Invalid JSON tool arguments: {e}"))),
+            Ok(value) => value,
+            Err(error) => return Some(Err(format!("Invalid JSON tool arguments: {error}"))),
         };
 
-        match config.transport {
-            McpTransport::Stdio { command, args, env } => {
-                let mut cmd = Command::new(&command);
-                cmd.args(&args);
-                for (k, v) in &env {
-                    cmd.env(k, v);
-                }
-                cmd.stdin(Stdio::piped())
-                    .stdout(Stdio::piped())
-                    .stderr(Stdio::null());
-
-                let mut child = match cmd.spawn() {
-                    Ok(c) => c,
-                    Err(e) => return Some(Err(format!("Failed to spawn MCP server: {e}"))),
-                };
-
-                let mut stdin = child.stdin.take().unwrap();
-                let stdout = child.stdout.take().unwrap();
-                let mut reader = BufReader::new(stdout);
-
-                // Handshake
-                let init_req = json!({
-                    "jsonrpc": "2.0",
-                    "id": 1,
-                    "method": "initialize",
-                    "params": {
-                        "protocolVersion": "2024-11-05",
-                        "capabilities": {},
-                        "clientInfo": { "name": "threadlane", "version": env!("CARGO_PKG_VERSION") }
-                    }
-                });
-                let _ = stdin.write_all(format!("{}\n", init_req).as_bytes()).await;
-
-                let mut line = String::new();
-                let _ =
-                    tokio::time::timeout(Duration::from_secs(5), reader.read_line(&mut line)).await;
-
-                let init_notif = json!({ "jsonrpc": "2.0", "method": "notifications/initialized" });
-                let _ = stdin
-                    .write_all(format!("{}\n", init_notif).as_bytes())
-                    .await;
-
-                // Execute call
-                let call_req = json!({
-                    "jsonrpc": "2.0",
-                    "id": 2,
-                    "method": "tools/call",
-                    "params": {
-                        "name": tool_name,
-                        "arguments": parsed_args
-                    }
-                });
-                let _ = stdin.write_all(format!("{}\n", call_req).as_bytes()).await;
-
-                line.clear();
-                let read_res =
-                    tokio::time::timeout(Duration::from_secs(15), reader.read_line(&mut line))
-                        .await;
-                let _ = child.kill().await;
-
-                if read_res.is_err() || line.trim().is_empty() {
-                    return Some(Err("MCP tool execution timed out".into()));
-                }
-
-                let response_json: Value = match serde_json::from_str(line.trim()) {
-                    Ok(v) => v,
-                    Err(e) => {
-                        return Some(Err(format!("Failed to parse tool execution response: {e}")))
-                    }
-                };
-
-                if let Some(err) = response_json.get("error") {
-                    let msg = err
-                        .get("message")
-                        .and_then(|m| m.as_str())
-                        .unwrap_or("MCP error");
-                    return Some(Err(msg.to_string()));
-                }
-
-                let mut output = String::new();
-                if let Some(content) = response_json
-                    .get("result")
-                    .and_then(|r| r.get("content"))
-                    .and_then(|c| c.as_array())
-                {
-                    for item in content {
-                        if let Some(text) = item.get("text").and_then(|t| t.as_str()) {
-                            if !output.is_empty() {
-                                output.push('\n');
-                            }
-                            output.push_str(text);
+        // Resolve the handle under the map lock, then release it before doing
+        // any I/O so concurrent calls to other servers are not serialized.
+        let handle = {
+            let existing = self.sessions.lock().await.get(&config.id).cloned();
+            match existing {
+                Some(handle) => handle,
+                None => {
+                    // A server that died between calls is restarted once rather
+                    // than failing the tool call outright.
+                    let session = match McpSession::connect(&config).await {
+                        Ok(session) => session,
+                        Err(error) => {
+                            return Some(Err(format!("Failed to start MCP server: {error}")))
                         }
+                    };
+                    let handle = Arc::new(TokioMutex::new(session));
+                    self.sessions
+                        .lock()
+                        .await
+                        .insert(config.id.clone(), Arc::clone(&handle));
+                    handle
+                }
+            }
+        };
+
+        let response = {
+            let mut session = handle.lock().await;
+            session
+                .request(
+                    "tools/call",
+                    json!({ "name": tool_name, "arguments": parsed_args }),
+                )
+                .await
+        };
+
+        let response = match response {
+            Ok(response) => response,
+            Err(error) => {
+                // The pipe is no longer trustworthy after a failed exchange;
+                // drop it so the next call starts a clean session.
+                let broken = self.sessions.lock().await.remove(&config.id);
+                if let Some(broken) = broken {
+                    if let Ok(broken) = Arc::try_unwrap(broken) {
+                        broken.into_inner().shutdown().await;
                     }
                 }
-
-                if output.is_empty() {
-                    output = serde_json::to_string_pretty(&response_json).unwrap_or_default();
-                }
-
-                Some(Ok(output))
+                return Some(Err(error));
             }
-            McpTransport::Sse { url, .. } => Some(Err(format!(
-                "SSE transport for {url} not currently supported"
-            ))),
+        };
+
+        let mut output = String::new();
+        if let Some(content) = response.get("content").and_then(Value::as_array) {
+            for item in content {
+                if let Some(text) = item.get("text").and_then(Value::as_str) {
+                    if !output.is_empty() {
+                        output.push('\n');
+                    }
+                    output.push_str(text);
+                }
+            }
         }
+        if output.is_empty() {
+            output = serde_json::to_string_pretty(&response).unwrap_or_default();
+        }
+        Some(Ok(output))
     }
 }
 

--- a/crates/threadlane-mcp/tests/perf_baseline.rs
+++ b/crates/threadlane-mcp/tests/perf_baseline.rs
@@ -1,0 +1,92 @@
+//! Measurement harness for MCP tool-call latency.
+//!
+//! Ignored by default: it spawns real subprocesses and reports timings rather
+//! than asserting behavior. Run with
+//! `cargo test -p threadlane-mcp --test perf_baseline -- --ignored --nocapture`.
+
+use std::collections::HashMap;
+use std::path::PathBuf;
+use std::sync::Arc;
+use std::time::Instant;
+use threadlane_agent::ToolExecutor;
+use threadlane_mcp::{
+    McpManager, McpScope, McpServerConfig, McpSettings, McpToolExecutor, McpTransport,
+};
+
+fn stub_server_script(dir: &std::path::Path) -> PathBuf {
+    let path = dir.join("stub_mcp.sh");
+    std::fs::write(
+        &path,
+        r#"#!/bin/sh
+# Minimal MCP stdio server. Echoes the request id, as JSON-RPC requires.
+# Uses parameter expansion only: forking per request would tax the per-call
+# measurement and hide what is actually being compared.
+while IFS= read -r line; do
+  rest=${line#*\"id\":}
+  id=${rest%%,*}
+  case "$line" in
+    *'"initialize"'*)
+      printf '{"jsonrpc":"2.0","id":%s,"result":{"protocolVersion":"2024-11-05","capabilities":{},"serverInfo":{"name":"stub","version":"1"}}}\n' "$id" ;;
+    *'"tools/list"'*)
+      printf '{"jsonrpc":"2.0","id":%s,"result":{"tools":[{"name":"echo","description":"echo","inputSchema":{"type":"object","properties":{}}}]}}\n' "$id" ;;
+    *'"tools/call"'*)
+      printf '{"jsonrpc":"2.0","id":%s,"result":{"content":[{"type":"text","text":"ok"}]}}\n' "$id" ;;
+  esac
+done
+"#,
+    )
+    .unwrap();
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        std::fs::set_permissions(&path, std::fs::Permissions::from_mode(0o755)).unwrap();
+    }
+    path
+}
+
+fn write_config(global_dir: &std::path::Path, script: &std::path::Path) {
+    let config = McpServerConfig {
+        id: "stub".to_string(),
+        name: "Stub".to_string(),
+        transport: McpTransport::Stdio {
+            command: script.to_string_lossy().to_string(),
+            args: Vec::new(),
+            env: HashMap::new(),
+        },
+        enabled: true,
+        scope: McpScope::Global,
+    };
+    McpSettings::save_global(global_dir, &[config]).unwrap();
+}
+
+#[tokio::test]
+#[ignore = "measurement harness, not an assertion"]
+async fn mcp_tool_call_latency() {
+    const CALLS: u32 = 20;
+
+    let dir = tempfile::tempdir().unwrap();
+    let script = stub_server_script(dir.path());
+    write_config(dir.path(), &script);
+
+    let manager = Arc::new(McpManager::new(Some(dir.path().to_path_buf()), None));
+
+    let discover_start = Instant::now();
+    let records = manager.discover_and_connect().await;
+    let discover = discover_start.elapsed();
+    assert_eq!(records.len(), 1, "stub server should be discovered");
+
+    // Exercise the same path the agent uses.
+    let executor = McpToolExecutor::new(Arc::clone(&manager));
+    let call_start = Instant::now();
+    for _ in 0..CALLS {
+        let result = executor.execute_tool("mcp__stub__echo", "{}").await;
+        assert!(matches!(result, Some(Ok(_))), "stub call should succeed");
+    }
+    let calls = call_start.elapsed();
+
+    println!("\n--- MCP latency ---");
+    println!("discover_and_connect : {discover:?}");
+    println!("{CALLS} tool calls      : {calls:?}");
+    println!("per tool call        : {:?}", calls / CALLS);
+    println!("-------------------\n");
+}

--- a/crates/threadlane-mcp/tests/session_reuse.rs
+++ b/crates/threadlane-mcp/tests/session_reuse.rs
@@ -1,0 +1,174 @@
+//! Guards that MCP servers are started once and reused across tool calls.
+//!
+//! Asserts on the number of processes actually started rather than on timing,
+//! so it fails for the right reason on a loaded CI machine.
+
+use std::collections::HashMap;
+use std::path::{Path, PathBuf};
+use std::sync::Arc;
+use threadlane_agent::ToolExecutor;
+use threadlane_mcp::{
+    McpManager, McpScope, McpServerConfig, McpSettings, McpToolExecutor, McpTransport,
+};
+
+/// Writes a stub server that appends one line to `spawn_log` each time it starts.
+fn stub_server(dir: &Path, spawn_log: &Path) -> PathBuf {
+    let path = dir.join("stub_mcp.sh");
+    std::fs::write(
+        &path,
+        format!(
+            r#"#!/bin/sh
+echo started >> "{log}"
+while IFS= read -r line; do
+  rest=${{line#*\"id\":}}
+  id=${{rest%%,*}}
+  case "$line" in
+    *'"initialize"'*)
+      printf '{{"jsonrpc":"2.0","id":%s,"result":{{"protocolVersion":"2024-11-05","capabilities":{{}}}}}}\n' "$id" ;;
+    *'"tools/list"'*)
+      printf '{{"jsonrpc":"2.0","id":%s,"result":{{"tools":[{{"name":"echo","description":"echo","inputSchema":{{"type":"object"}}}}]}}}}\n' "$id" ;;
+    *'"tools/call"'*)
+      printf '{{"jsonrpc":"2.0","id":%s,"result":{{"content":[{{"type":"text","text":"ok"}}]}}}}\n' "$id" ;;
+  esac
+done
+"#,
+            log = spawn_log.display()
+        ),
+    )
+    .unwrap();
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        std::fs::set_permissions(&path, std::fs::Permissions::from_mode(0o755)).unwrap();
+    }
+    path
+}
+
+fn spawn_count(spawn_log: &Path) -> usize {
+    std::fs::read_to_string(spawn_log)
+        .map(|text| text.lines().filter(|line| !line.trim().is_empty()).count())
+        .unwrap_or(0)
+}
+
+#[tokio::test]
+async fn tool_calls_reuse_one_server_process() {
+    let dir = tempfile::tempdir().unwrap();
+    let spawn_log = dir.path().join("spawns.log");
+    let script = stub_server(dir.path(), &spawn_log);
+
+    McpSettings::save_global(
+        dir.path(),
+        &[McpServerConfig {
+            id: "stub".to_string(),
+            name: "Stub".to_string(),
+            transport: McpTransport::Stdio {
+                command: script.to_string_lossy().to_string(),
+                args: Vec::new(),
+                env: HashMap::new(),
+            },
+            enabled: true,
+            scope: McpScope::Global,
+        }],
+    )
+    .unwrap();
+
+    let manager = Arc::new(McpManager::new(Some(dir.path().to_path_buf()), None));
+    let records = manager.discover_and_connect().await;
+    assert_eq!(records.len(), 1);
+    assert_eq!(
+        spawn_count(&spawn_log),
+        1,
+        "discovery should start the server exactly once"
+    );
+
+    let executor = McpToolExecutor::new(Arc::clone(&manager));
+    for call in 0..5 {
+        let result = executor.execute_tool("mcp__stub__echo", "{}").await;
+        assert!(
+            matches!(result, Some(Ok(ref text)) if text == "ok"),
+            "call {call} should succeed, got {result:?}"
+        );
+    }
+
+    // The whole point of the change: five calls, still one process.
+    assert_eq!(
+        spawn_count(&spawn_log),
+        1,
+        "tool calls must reuse the running server rather than respawning it"
+    );
+
+    manager.shutdown().await;
+}
+
+#[tokio::test]
+async fn a_dead_server_is_restarted_on_the_next_call() {
+    let dir = tempfile::tempdir().unwrap();
+    let spawn_log = dir.path().join("spawns.log");
+    // This stub exits after answering the handshake and one listing, so the
+    // first tool call finds a dead pipe.
+    let script = dir.path().join("dying_mcp.sh");
+    std::fs::write(
+        &script,
+        format!(
+            r#"#!/bin/sh
+echo started >> "{log}"
+count=0
+while IFS= read -r line; do
+  rest=${{line#*\"id\":}}
+  id=${{rest%%,*}}
+  case "$line" in
+    *'"initialize"'*)
+      printf '{{"jsonrpc":"2.0","id":%s,"result":{{}}}}\n' "$id" ;;
+    *'"tools/list"'*)
+      printf '{{"jsonrpc":"2.0","id":%s,"result":{{"tools":[{{"name":"echo","description":"e","inputSchema":{{"type":"object"}}}}]}}}}\n' "$id" ;;
+    *'"tools/call"'*)
+      count=$((count+1))
+      if [ "$count" -ge 1 ]; then exit 0; fi ;;
+  esac
+done
+"#,
+            log = spawn_log.display()
+        ),
+    )
+    .unwrap();
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        std::fs::set_permissions(&script, std::fs::Permissions::from_mode(0o755)).unwrap();
+    }
+
+    McpSettings::save_global(
+        dir.path(),
+        &[McpServerConfig {
+            id: "stub".to_string(),
+            name: "Stub".to_string(),
+            transport: McpTransport::Stdio {
+                command: script.to_string_lossy().to_string(),
+                args: Vec::new(),
+                env: HashMap::new(),
+            },
+            enabled: true,
+            scope: McpScope::Global,
+        }],
+    )
+    .unwrap();
+
+    let manager = Arc::new(McpManager::new(Some(dir.path().to_path_buf()), None));
+    manager.discover_and_connect().await;
+    let executor = McpToolExecutor::new(Arc::clone(&manager));
+
+    // First call loses the server and must report an error rather than hanging.
+    let first = executor.execute_tool("mcp__stub__echo", "{}").await;
+    assert!(matches!(first, Some(Err(_))), "got {first:?}");
+
+    // The broken session must have been retired, so the next call starts a new
+    // process instead of reusing a dead pipe forever.
+    let before = spawn_count(&spawn_log);
+    let _ = executor.execute_tool("mcp__stub__echo", "{}").await;
+    assert!(
+        spawn_count(&spawn_log) > before,
+        "a dead server should be restarted on the next call"
+    );
+
+    manager.shutdown().await;
+}


### PR DESCRIPTION
Performance work done under a measurement gate: nothing here was changed without a before/after number, and one candidate was measured and deliberately left alone.

## Results

| Path | Before | After | Change |
| --- | --- | --- | --- |
| MCP tool call | 5.109 ms | 0.125 ms | **~41× faster** |
| Session file load (4000 nodes) | 62.1 ms | 54.2 ms | ~13% faster |
| Workspace file tree scan | 3.3 ms / 302 nodes | *unchanged* | measured, not worth touching |

Both before and after were measured on the same machine against the same stub, by stashing the source change and re-running the identical harness.

## 1. MCP servers are now reused instead of respawned per call

Every MCP tool call spawned a fresh server process, ran the full `initialize` handshake, issued one `tools/call`, and killed the process. `McpManager` now holds one live `McpSession` per server id and reuses it.

**The 5 ms figure is a floor, not a typical case.** The benchmark stub is a shell script that costs almost nothing to spawn. A real `npx`- or Python-based MCP server takes hundreds of milliseconds to boot, and that entire cost was being paid on *every single tool call*. On a real setup the saving is considerably larger than what the table shows.

Three details worth review attention:

- **Locking.** Each session carries its own lock, and the session map is held only long enough to look up or install a handle — never across the request round trip. My first version held the map lock across the I/O, which serialized every MCP call behind every other one and violated the repo's "no locks across async boundaries" rule. Fixed before this landed.
- **Response correlation.** The new client matches responses by request id. The old code read the next line and assumed it was the answer — a server emitting a notification mid-exchange would have desynchronized it. This is stricter, and it caught a bug in my own benchmark stub.
- **Failure and lifecycle.** A failed exchange retires the session so the next call reconnects rather than reusing a dead pipe. `Command::kill_on_drop` cleans up when the manager drops; I verified no stray processes survive a run.

## 2. Session files are parsed once

Loading tried `SessionRecord`, then fell back to `SessionNode` — parsing the JSON *text* of every node line twice, and node lines are the overwhelming majority. An untagged `SessionLine` enum buffers the parse once and matches variants against that buffer. Modest but consistent across sizes, with no behavior change.

## 3. What I measured and did not change

The workspace file tree scan runs in **3.3 ms for 302 nodes**. It has a mildly wasteful `file_type()` call in its sort comparator, but at that cost it does not matter. Changing it would have been diff churn, so I left it.

## Testing

Regression coverage is **behavioral, not timing-based** — `tests/session_reuse.rs` counts how many server processes actually start, so it fails for the right reason on a loaded CI machine:

- five tool calls must start exactly one process
- a server that dies mid-session must be restarted on the next call rather than leaving a permanently dead pipe

The measurement harnesses are `#[ignore]`d so they never run in normal CI:

```bash
cargo test -p threadlane-mcp --test perf_baseline -- --ignored --nocapture
cargo test -p threadlane-agent --test perf_baseline -- --ignored --nocapture
```

`cargo test --workspace` passes, clippy is clean on the touched crates, `git diff --check` is clean, and the app launches with zero DSL errors.

**Not covered:** UI frame latency. I cannot drive the GUI to measure input-to-paint, so scrolling, typing, and panel-switching smoothness are untouched and unmeasured here. Everything in this PR is agent-turnaround and session-load work, which is where the measurable wins were.