### PR TITLE
Centralize workspace version metadata for updater detection

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3422,7 +3422,7 @@ dependencies = [
 
 [[package]]
 name = "threadlane"
-version = "0.0.9"
+version = "0.1.2"
 dependencies = [
  "arboard",
  "base64",
@@ -3588,7 +3588,7 @@ dependencies = [
 
 [[package]]
 name = "threadlane-updater"
-version = "0.1.0"
+version = "0.1.2"
 dependencies = [
  "cargo-packager-updater",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,6 +5,10 @@ members = [
 ]
 resolver = "2"
 
+[workspace.package]
+version = "0.1.2"
+edition = "2021"
+
 [profile.dev]
 opt-level = 0
 debug = true

--- a/crates/threadlane-updater/Cargo.toml
+++ b/crates/threadlane-updater/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "threadlane-updater"
-version = "0.1.0"
-edition = "2021"
+version.workspace = true
+edition.workspace = true
 description = "Signed application update checks and background downloads for threadlane agent"
 
 [dependencies]

--- a/crates/threadlane/Cargo.toml
+++ b/crates/threadlane/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "threadlane"
-version = "0.1.0"
-edition = "2021"
+version.workspace = true
+edition.workspace = true
 description = "GPU Desktop UI application for threadlane agent using Makepad"
 
 [dependencies]


### PR DESCRIPTION
## Summary

- Define the workspace version as `0.1.2` with shared Rust edition metadata
- Make the Threadlane application and updater inherit workspace package settings
- Synchronize `Cargo.lock` package versions for release and updater detection

## Testing

Not run (not requested)