### PR TITLE
Fix threadlane-tools CI dependency resolution

### DIFF
--- a/crates/threadlane-tools/Cargo.toml
+++ b/crates/threadlane-tools/Cargo.toml
@@ -5,7 +5,7 @@ edition = "2021"
 description = "Built-in coding tools and execution primitives for threadlane agent"
 
 [dependencies]
-threadlane-hashline = { path = "../threadlane-hashline" }
+threadlane-hashline = { version = "0.1.0", path = "../threadlane-hashline" }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 


### PR DESCRIPTION
## Summary

- Add the published `threadlane-hashline` version to the local path dependency declaration.
- Keep workspace development using the local crate while enabling CI and package metadata resolution.

## Testing

- Not run (not requested).