### PR TITLE
🧪 Add test for build_authorization_url

### DIFF
--- a/crates/threadlane-auth/src/antigravity_auth.rs
+++ b/crates/threadlane-auth/src/antigravity_auth.rs
@@ -428,6 +428,42 @@ mod tests {
     }
 
     #[test]
+    fn test_build_authorization_url() {
+        let code_challenge = "test_challenge_123";
+        let state = "test_state_456";
+        let url_str = build_authorization_url(code_challenge, state);
+
+        let url = url::Url::parse(&url_str).unwrap();
+
+        assert_eq!(url.scheme(), "https");
+        assert_eq!(url.host_str(), Some("accounts.google.com"));
+        assert_eq!(url.path(), "/o/oauth2/v2/auth");
+
+        let query_params: std::collections::HashMap<_, _> = url.query_pairs().into_owned().collect();
+
+        assert_eq!(query_params.get("response_type").unwrap(), "code");
+        assert_eq!(query_params.get("code_challenge").unwrap(), code_challenge);
+        assert_eq!(query_params.get("code_challenge_method").unwrap(), "S256");
+        assert_eq!(query_params.get("access_type").unwrap(), "offline");
+        assert_eq!(query_params.get("prompt").unwrap(), "consent");
+        assert_eq!(query_params.get("state").unwrap(), state);
+        assert_eq!(query_params.get("redirect_uri").unwrap(), DEFAULT_REDIRECT_URI);
+
+        let scopes = query_params.get("scope").unwrap();
+        assert!(scopes.contains("https://www.googleapis.com/auth/cloud-platform"));
+        assert!(scopes.contains("https://www.googleapis.com/auth/userinfo.email"));
+        assert!(scopes.contains("https://www.googleapis.com/auth/userinfo.profile"));
+        assert!(scopes.contains("https://www.googleapis.com/auth/cclog"));
+        assert!(scopes.contains("https://www.googleapis.com/auth/experimentsandconfigs"));
+
+        if let Ok(client_id) = std::env::var("ANTIGRAVITY_CLIENT_ID") {
+            assert_eq!(query_params.get("client_id").unwrap(), &client_id);
+        } else {
+            assert_eq!(query_params.get("client_id").unwrap(), DEFAULT_CLIENT_ID);
+        }
+    }
+
+    #[test]
     fn test_antigravity_provider_id() {
         let provider = AntigravityAuthProvider;
         assert_eq!(provider.provider_id(), "antigravity");


### PR DESCRIPTION
🎯 **What:** Added tests for the `build_authorization_url` function in `crates/threadlane-auth/src/antigravity_auth.rs` to address the missing test gap for OAuth URL generation.
📊 **Coverage:** The test covers the happy path by generating a URL with a test challenge and state. It parses the resulting URL and asserts that the base components (scheme, host, path) and all required query parameters (`response_type`, `code_challenge`, `code_challenge_method`, `access_type`, `prompt`, `state`, `redirect_uri`, `scope`, and `client_id`) are formatted correctly according to expected standards. It safely handles the dynamic `client_id` by checking the environment variable.
✨ **Result:** Enhanced test coverage for the `antigravity_auth` module, ensuring that the OAuth authorization URL is built consistently and correctly, preventing potential regressions in the authentication flow.

---
*PR created automatically by Jules for task [4440744037067209522](https://jules.google.com/task/4440744037067209522) started by @wheregmis*