### PR TITLE
Fix release-plz workspace dependency packaging

### DIFF
--- a/crates/threadlane-agent/Cargo.toml
+++ b/crates/threadlane-agent/Cargo.toml
@@ -5,8 +5,8 @@ edition = "2021"
 description = "Generic LLM session state, system prompt, and agent execution loop"
 
 [dependencies]
-threadlane-provider = { path = "../threadlane-provider" }
-threadlane-tools = { path = "../threadlane-tools" }
+threadlane-provider = { version = "0.1.0", path = "../threadlane-provider" }
+threadlane-tools = { version = "0.1.0", path = "../threadlane-tools" }
 tokio = { version = "1.38", features = ["full"] }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"

--- a/crates/threadlane-cli/Cargo.toml
+++ b/crates/threadlane-cli/Cargo.toml
@@ -9,13 +9,13 @@ name = "threadlane"
 path = "src/main.rs"
 
 [dependencies]
-threadlane-coding-agent = { path = "../threadlane-coding-agent" }
-threadlane-agent = { path = "../threadlane-agent" }
-threadlane-auth = { path = "../threadlane-auth" }
-threadlane-provider = { path = "../threadlane-provider" }
-threadlane-git = { path = "../threadlane-git" }
-threadlane-tools = { path = "../threadlane-tools" }
-threadlane-skills = { path = "../threadlane-skills" }
+threadlane-coding-agent = { version = "0.1.0", path = "../threadlane-coding-agent" }
+threadlane-agent = { version = "0.1.0", path = "../threadlane-agent" }
+threadlane-auth = { version = "0.1.0", path = "../threadlane-auth" }
+threadlane-provider = { version = "0.1.0", path = "../threadlane-provider" }
+threadlane-git = { version = "0.1.0", path = "../threadlane-git" }
+threadlane-tools = { version = "0.1.0", path = "../threadlane-tools" }
+threadlane-skills = { version = "0.1.0", path = "../threadlane-skills" }
 
 ratatui = "0.29"
 crossterm = "0.28"

--- a/crates/threadlane-coding-agent/Cargo.toml
+++ b/crates/threadlane-coding-agent/Cargo.toml
@@ -5,12 +5,12 @@ edition = "2021"
 description = "Coding agent harness built on top of threadlane-agent and threadlane-tools"
 
 [dependencies]
-threadlane-agent = { path = "../threadlane-agent" }
-threadlane-tools = { path = "../threadlane-tools" }
-threadlane-provider = { path = "../threadlane-provider" }
-threadlane-mcp = { path = "../threadlane-mcp" }
-threadlane-skills = { path = "../threadlane-skills" }
-threadlane-wasi = { path = "../threadlane-wasi" }
+threadlane-agent = { version = "0.1.0", path = "../threadlane-agent" }
+threadlane-tools = { version = "0.1.0", path = "../threadlane-tools" }
+threadlane-provider = { version = "0.1.0", path = "../threadlane-provider" }
+threadlane-mcp = { version = "0.1.0", path = "../threadlane-mcp" }
+threadlane-skills = { version = "0.1.0", path = "../threadlane-skills" }
+threadlane-wasi = { version = "0.1.0", path = "../threadlane-wasi" }
 tokio = { version = "1.38", features = ["full"] }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"

--- a/crates/threadlane-mcp/Cargo.toml
+++ b/crates/threadlane-mcp/Cargo.toml
@@ -5,7 +5,7 @@ edition = "2021"
 description = "Model Context Protocol (MCP) client engine for threadlane agent"
 
 [dependencies]
-threadlane-agent = { path = "../threadlane-agent" }
+threadlane-agent = { version = "0.1.0", path = "../threadlane-agent" }
 tokio = { version = "1.38", features = ["full"] }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"

--- a/crates/threadlane-provider/Cargo.toml
+++ b/crates/threadlane-provider/Cargo.toml
@@ -5,8 +5,8 @@ edition = "2021"
 description = "OpenAI REST & Codex backend streaming client and device auth for threadlane agent"
 
 [dependencies]
-threadlane-tools = { path = "../threadlane-tools" }
-threadlane-auth = { path = "../threadlane-auth" }
+threadlane-tools = { version = "0.1.0", path = "../threadlane-tools" }
+threadlane-auth = { version = "0.1.0", path = "../threadlane-auth" }
 async-trait = "0.1"
 tokio = { version = "1.38", features = ["full"] }
 reqwest = { version = "0.12", features = ["json", "stream"] }

--- a/crates/threadlane-skills/Cargo.toml
+++ b/crates/threadlane-skills/Cargo.toml
@@ -5,7 +5,7 @@ edition = "2021"
 description = "Skill directory scanning, YAML frontmatter parsing, and load_skill tool for threadlane agent"
 
 [dependencies]
-threadlane-agent = { path = "../threadlane-agent" }
+threadlane-agent = { version = "0.1.0", path = "../threadlane-agent" }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 serde_yaml = "0.9"

--- a/crates/threadlane-wasi/Cargo.toml
+++ b/crates/threadlane-wasi/Cargo.toml
@@ -5,7 +5,7 @@ edition = "2021"
 description = "WASI WebAssembly extension sandbox host and capability broker for threadlane agent"
 
 [dependencies]
-threadlane-agent = { path = "../threadlane-agent" }
+threadlane-agent = { version = "0.1.0", path = "../threadlane-agent" }
 wasmi = "0.36"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"

--- a/crates/threadlane/Cargo.toml
+++ b/crates/threadlane/Cargo.toml
@@ -9,12 +9,12 @@ makepad-widgets = { git = "https://github.com/makepad/makepad.git", branch = "de
 makepad-terminal-core = { git = "https://github.com/makepad/makepad.git", branch = "dev" }
 makepad-code-editor = { git = "https://github.com/makepad/makepad.git", branch = "dev" }
 unicode-segmentation = "1.12.0"
-threadlane-agent = { path = "../threadlane-agent" }
-threadlane-coding-agent = { path = "../threadlane-coding-agent" }
-threadlane-provider = { path = "../threadlane-provider" }
-threadlane-tools = { path = "../threadlane-tools" }
-threadlane-git = { path = "../threadlane-git" }
-threadlane-updater = { path = "../threadlane-updater" }
+threadlane-agent = { version = "0.1.0", path = "../threadlane-agent" }
+threadlane-coding-agent = { version = "0.1.0", path = "../threadlane-coding-agent" }
+threadlane-provider = { version = "0.1.0", path = "../threadlane-provider" }
+threadlane-tools = { version = "0.1.0", path = "../threadlane-tools" }
+threadlane-git = { version = "0.1.0", path = "../threadlane-git" }
+threadlane-updater = { version = "0.1.0", path = "../threadlane-updater" }
 tokio = { version = "1.38", features = ["full"] }
 reqwest = { version = "0.12", features = ["json", "rustls-tls"] }
 serde = { version = "1.0", features = ["derive"] }


### PR DESCRIPTION
Release-plz packages all workspace crates and requires version requirements on every internal path dependency.

- Add `version = "0.1.0"` to all internal path dependencies.
- `cargo check --workspace` passes.
- `git diff --check` passes.