### PR TITLE
Keep updater dependency compatible with workspace bumps

### DIFF
--- a/crates/threadlane/Cargo.toml
+++ b/crates/threadlane/Cargo.toml
@@ -14,7 +14,7 @@ threadlane-coding-agent = { version = "0.1.0", path = "../threadlane-coding-agen
 threadlane-provider = { version = "0.1.0", path = "../threadlane-provider" }
 threadlane-tools = { version = "0.1.0", path = "../threadlane-tools" }
 threadlane-git = { version = "0.1.0", path = "../threadlane-git" }
-threadlane-updater = { version = "0.1.0", path = "../threadlane-updater" }
+threadlane-updater = { version = ">=0.1.0, <1.0.0", path = "../threadlane-updater" }
 tokio = { version = "1.38", features = ["full"] }
 reqwest = { version = "0.12", features = ["json", "rustls-tls"] }
 serde = { version = "1.0", features = ["derive"] }


### PR DESCRIPTION
The updater package inherits its version from the workspace. Keep the internal path dependency compatible with future 0.x workspace bumps, including 0.2.0.

Verified with `cargo check -p threadlane` at the current version and a simulated workspace 0.2.0 bump.