### PR TITLE
fix: document Release Please commit requirements

### DIFF
--- a/README.md
+++ b/README.md
@@ -459,6 +459,8 @@ or updates a release pull request containing the next workspace version and the
 root [`CHANGELOG.md`](CHANGELOG.md). Merging that pull request creates a
 `v<version>` tag and GitHub release. The release notes include the generated
 changelog entries for the included conventional commits.
+At least one included commit must use a release-worthy Conventional Commit
+prefix such as `fix:` or `feat:`; other messages do not trigger a release PR.
 
 The automation is split between
 [`.github/workflows/release-please.yml`](.github/workflows/release-please.yml), which


### PR DESCRIPTION
## Summary

- document that release-worthy commits need Conventional Commit prefixes
- provide a `fix:` commit that bootstraps the first Release Please PR

## Root cause

Release Please found the existing commits but skipped them because none produced user-facing conventional release notes. After this PR merges, its `fix:` commit will trigger the `0.1.3` release PR.

## Validation

- verified the commit with the `release-please@17.6.0` conventional-commit parser
- `git diff origin/main...HEAD --check`
