### PR TITLE
fix: publish artifacts from reusable releases

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -50,7 +50,7 @@ jobs:
           targets: wasm32-wasip1
 
       - name: Verify release tag matches the app version
-        if: github.event_name == 'workflow_call' || startsWith(github.ref, 'refs/tags/')
+        if: inputs.release_tag != '' || startsWith(github.ref, 'refs/tags/')
         shell: bash
         run: |
           APP_VERSION=$(cargo metadata --no-deps --format-version 1 \
@@ -143,7 +143,7 @@ jobs:
           codesign --verify --strict --verbose=4 "${dmgs[0]}"
 
       - name: Generate signed update manifest
-        if: github.event_name == 'workflow_call' || startsWith(github.ref, 'refs/tags/')
+        if: inputs.release_tag != '' || startsWith(github.ref, 'refs/tags/')
         shell: bash
         env:
           GH_TOKEN: ${{ github.token }}
@@ -186,7 +186,7 @@ jobs:
 
       - name: Upload Release Assets
         uses: softprops/action-gh-release@v2
-        if: github.event_name == 'workflow_call' || startsWith(github.ref, 'refs/tags/')
+        if: inputs.release_tag != '' || startsWith(github.ref, 'refs/tags/')
         with:
           tag_name: ${{ env.RELEASE_TAG }}
           files: |
@@ -202,7 +202,7 @@ jobs:
     name: Build & Package (Ubuntu 24.04 x86_64)
     if: >-
       ${{
-        github.event_name == 'workflow_call' ||
+        inputs.release_tag != '' ||
         startsWith(github.ref, 'refs/tags/') ||
         (github.event_name == 'workflow_dispatch' && inputs.build_ubuntu_24_x86_64)
       }}
@@ -281,7 +281,7 @@ jobs:
           fi
 
       - name: Upload Ubuntu Release Asset
-        if: github.event_name == 'workflow_call' || startsWith(github.ref, 'refs/tags/')
+        if: inputs.release_tag != '' || startsWith(github.ref, 'refs/tags/')
         uses: softprops/action-gh-release@v2
         with:
           tag_name: ${{ env.RELEASE_TAG }}


### PR DESCRIPTION
## Summary

- run publication steps when the reusable workflow receives a `release_tag`
- preserve direct tag and manual-dispatch behavior

## Root cause

Reusable workflows retain the caller's event context. A Release Please invocation therefore appears as a `push` to `main`, not `workflow_call`, which skipped the manifest, upload, and Ubuntu packaging guards after the macOS build succeeded.

## Validation

- parsed the release workflow YAML
- verified all five reusable-workflow guards depend on `inputs.release_tag`
- verified no obsolete `github.event_name == 'workflow_call'` guard remains
- `git diff --cached --check`
