### PR TITLE
feat: Add chat navigation and steering shortcuts

### DIFF
--- a/crates/threadlane-gpui/src/app/actions.rs
+++ b/crates/threadlane-gpui/src/app/actions.rs
@@ -49,4 +49,5 @@ pub enum AppAction {
     RemoveCodexAccount(String),
     ToggleReasoningExpanded(String),
     OpenFileInEditor(String),
+    RunTerminalCommand(String),
 }

--- a/crates/threadlane-gpui/src/app/actions.rs
+++ b/crates/threadlane-gpui/src/app/actions.rs
@@ -25,7 +25,7 @@ pub enum AppAction {
         text: String,
         images: Vec<ImageAttachment>,
     },
-    StageBusyMessage(String),
+    StageBusyMessage { text: String, images: Vec<ImageAttachment> },
     QueuePendingMessage,
     SteerPendingMessage,
     DismissPendingMessage,

--- a/crates/threadlane-gpui/src/app/controller.rs
+++ b/crates/threadlane-gpui/src/app/controller.rs
@@ -46,7 +46,9 @@ pub(crate) fn dispatch(state: &mut AppState, action: AppAction) -> Option<Sessio
             }
         }
         AppAction::StageBusyMessage { text, images } => {
-            let _ = state.stage_busy_message(text, images);
+            if let Err(error) = state.stage_busy_message(text, images) {
+                state.session_status = Some(error);
+            }
         }
         AppAction::QueuePendingMessage => {
             let _ = state.queue_pending_message();

--- a/crates/threadlane-gpui/src/app/controller.rs
+++ b/crates/threadlane-gpui/src/app/controller.rs
@@ -92,6 +92,7 @@ pub(crate) fn dispatch(state: &mut AppState, action: AppAction) -> Option<Sessio
             }
         }
         AppAction::OpenFileInEditor(path) => state.request_open_file(path),
+        AppAction::RunTerminalCommand(cmd) => state.request_run_terminal_command(cmd),
     }
     None
 }

--- a/crates/threadlane-gpui/src/app/controller.rs
+++ b/crates/threadlane-gpui/src/app/controller.rs
@@ -45,8 +45,8 @@ pub(crate) fn dispatch(state: &mut AppState, action: AppAction) -> Option<Sessio
                 state.session_status = Some(error);
             }
         }
-        AppAction::StageBusyMessage(text) => {
-            let _ = state.stage_busy_message(text);
+        AppAction::StageBusyMessage { text, images } => {
+            let _ = state.stage_busy_message(text, images);
         }
         AppAction::QueuePendingMessage => {
             let _ = state.queue_pending_message();

--- a/crates/threadlane-gpui/src/screens/chat/mod.rs
+++ b/crates/threadlane-gpui/src/screens/chat/mod.rs
@@ -1,3 +1,3 @@
 mod view;
 
-pub use view::{init, ChatListView};
+pub use view::{init, CentralTab, ChatListView};

--- a/crates/threadlane-gpui/src/screens/chat/view.rs
+++ b/crates/threadlane-gpui/src/screens/chat/view.rs
@@ -305,6 +305,10 @@ fn is_terminal_runnable_language(lang: &str) -> bool {
         "bash" | "sh" | "zsh" | "shell" | "terminal" | "console" | "cmd" | "powershell"
     )
 }
+fn is_fence_line(raw: &str, idx: usize) -> bool {
+    let line_start = raw[..idx].rfind('\n').map_or(0, |p| p + 1);
+    raw[line_start..idx].len() <= 3 && raw[line_start..idx].bytes().all(|b| b == b' ')
+}
 
 fn parse_code_block_header(header: &str, code: &str) -> (String, Option<String>) {
     let header_trimmed = header.trim();
@@ -379,7 +383,7 @@ pub fn extract_markdown_segments(raw: &str) -> Vec<MarkdownSegment> {
         let mut search_pos = code_start;
         while let Some(close_pos) = raw[search_pos..].find("```") {
             let candidate_idx = search_pos + close_pos;
-            if candidate_idx == 0 || raw.as_bytes()[candidate_idx - 1] == b'\n' {
+            if is_fence_line(raw, candidate_idx) {
                 close_fence_idx = Some(candidate_idx);
                 break;
             }
@@ -882,15 +886,11 @@ impl ChatListView {
                     let is_generating = model_clone.read(cx).is_generating;
                     if !text.trim().is_empty() || (!is_generating && !this.pasted_images.is_empty())
                     {
-                        let images = if is_generating {
-                            Vec::new()
-                        } else {
-                            std::mem::take(&mut this.pasted_images)
-                        };
+                        let images = std::mem::take(&mut this.pasted_images);
                         let is_steer = *secondary;
                         model_clone.update(cx, |state, cx| {
                             if is_generating {
-                                controller::dispatch(state, AppAction::StageBusyMessage(text));
+                                controller::dispatch(state, AppAction::StageBusyMessage { text, images });
                                 if is_steer {
                                     controller::dispatch(state, AppAction::SteerPendingMessage);
                                 } else {
@@ -2758,7 +2758,9 @@ impl ChatListView {
         let code_str = code.to_string();
         let copy_code = code.to_string();
         let is_runnable = is_terminal_runnable_language(language);
-        let path_opt = header_path.map(str::to_string);
+        let path_opt = header_path.and_then(|path| match classify_chat_link(path) {
+            ChatLinkTarget::ProjectFile(path) => Some(path), _ => None,
+        });
         let path_for_open = path_opt.clone();
 
         let display_lang = if language.trim().is_empty() {
@@ -2990,8 +2992,8 @@ impl ChatListView {
         let theme = cx.theme().colors;
         match msg.role {
             MessageRole::User => {
-                let is_queued =
-                    msg.id.starts_with("queued-user-") && self.model.read(cx).is_generating;
+                let is_queued = msg.id.starts_with("queued-user-") && self.model.read(cx).is_generating;
+                let is_steered = msg.id.starts_with("steered-user-") && self.model.read(cx).is_generating;
                 div()
                     .w_full()
                     .min_w_0()
@@ -3015,6 +3017,7 @@ impl ChatListView {
                                 ),
                         )
                     })
+                    .when(is_steered, |el| el.child(div().child(Tag::new().child("Steering current turn").with_variant(TagVariant::Primary).small())))
                     .child(
                         div()
                             .min_w_0()
@@ -4676,7 +4679,8 @@ impl ChatListView {
                                                 let text = queue_prompt_input.read(cx).value().to_string();
                                                 if !text.trim().is_empty() {
                                                     queue_prompt_model.update(cx, |state, cx| {
-                                                        controller::dispatch(state, AppAction::StageBusyMessage(text));
+                                                        let images = std::mem::take(&mut this.pasted_images);
+                                                        controller::dispatch(state, AppAction::StageBusyMessage { text, images });
                                                         controller::dispatch(state, AppAction::QueuePendingMessage);
                                                         cx.notify();
                                                     });
@@ -4698,7 +4702,8 @@ impl ChatListView {
                                                 let text = steer_prompt_input.read(cx).value().to_string();
                                                 if !text.trim().is_empty() {
                                                     steer_prompt_model.update(cx, |state, cx| {
-                                                        controller::dispatch(state, AppAction::StageBusyMessage(text));
+                                                        let images = std::mem::take(&mut this.pasted_images);
+                                                        controller::dispatch(state, AppAction::StageBusyMessage { text, images });
                                                         controller::dispatch(state, AppAction::SteerPendingMessage);
                                                         cx.notify();
                                                     });
@@ -5683,6 +5688,12 @@ mod hot_path_tests {
                 code: "// app/routes/index.tsx\nexport default function Home() {}\n".into(),
             }
         );
+    }
+
+    #[test]
+    fn extract_markdown_segments_accepts_indented_closing_fence() {
+        let segments = extract_markdown_segments("```rust\nlet x = 1;\n  ```\nAfter");
+        assert!(matches!(segments.as_slice(), [MarkdownSegment::CodeBlock { .. }, MarkdownSegment::Markdown(text)] if text == "After"));
     }
 
     #[test]

--- a/crates/threadlane-gpui/src/screens/chat/view.rs
+++ b/crates/threadlane-gpui/src/screens/chat/view.rs
@@ -288,6 +288,145 @@ fn classify_chat_link(link: &str) -> ChatLinkTarget {
         ChatLinkTarget::ProjectFile(normalized.to_string_lossy().into_owned())
     }
 }
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum MarkdownSegment {
+    Markdown(String),
+    CodeBlock {
+        language: String,
+        header_path: Option<String>,
+        code: String,
+    },
+}
+
+fn is_terminal_runnable_language(lang: &str) -> bool {
+    matches!(
+        lang.to_lowercase().as_str(),
+        "bash" | "sh" | "zsh" | "shell" | "terminal" | "console" | "cmd" | "powershell"
+    )
+}
+
+fn parse_code_block_header(header: &str, code: &str) -> (String, Option<String>) {
+    let header_trimmed = header.trim();
+    let parts: Vec<&str> = header_trimmed.split_whitespace().collect();
+    let language = parts.first().copied().unwrap_or("text").to_lowercase();
+
+    let mut detected_path = if parts.len() > 1 {
+        Some(parts[1].to_string())
+    } else if let Some((_, path)) = language.split_once(':') {
+        Some(path.to_string())
+    } else {
+        None
+    };
+
+    let clean_language = language.split(':').next().unwrap_or("text").to_string();
+
+    if detected_path.is_none() {
+        if let Some(first_line) = code.lines().next() {
+            let trimmed = first_line.trim();
+            let comment_content = trimmed
+                .strip_prefix("//")
+                .or_else(|| trimmed.strip_prefix('#'))
+                .or_else(|| trimmed.strip_prefix("/*").and_then(|s| s.strip_suffix("*/")))
+                .or_else(|| trimmed.strip_prefix("<!--").and_then(|s| s.strip_suffix("-->")));
+
+            if let Some(candidate) = comment_content {
+                let candidate = candidate.trim();
+                if (candidate.contains('/') || candidate.contains('.'))
+                    && !candidate.contains(' ')
+                    && candidate.len() < 120
+                    && !candidate.starts_with("http")
+                {
+                    detected_path = Some(candidate.to_string());
+                }
+            }
+        }
+    }
+
+    (clean_language, detected_path)
+}
+
+pub fn extract_markdown_segments(raw: &str) -> Vec<MarkdownSegment> {
+    let mut segments = Vec::new();
+    let mut current_pos = 0;
+
+    while let Some(start_fence) = raw[current_pos..].find("```") {
+        let fence_start_idx = current_pos + start_fence;
+
+        let is_line_start = fence_start_idx == 0 || raw.as_bytes()[fence_start_idx - 1] == b'\n';
+        if !is_line_start {
+            current_pos = fence_start_idx + 3;
+            continue;
+        }
+
+        if fence_start_idx > current_pos {
+            let text = &raw[current_pos..fence_start_idx];
+            if !text.is_empty() {
+                segments.push(MarkdownSegment::Markdown(text.to_string()));
+            }
+        }
+
+        let header_start = fence_start_idx + 3;
+        let Some(header_newline) = raw[header_start..].find('\n') else {
+            segments.push(MarkdownSegment::Markdown(raw[fence_start_idx..].to_string()));
+            return segments;
+        };
+
+        let header_line = raw[header_start..header_start + header_newline].trim();
+        let code_start = header_start + header_newline + 1;
+
+        let mut close_fence_idx = None;
+        let mut search_pos = code_start;
+        while let Some(close_pos) = raw[search_pos..].find("```") {
+            let candidate_idx = search_pos + close_pos;
+            if candidate_idx == 0 || raw.as_bytes()[candidate_idx - 1] == b'\n' {
+                close_fence_idx = Some(candidate_idx);
+                break;
+            }
+            search_pos = candidate_idx + 3;
+        }
+
+        if let Some(close_idx) = close_fence_idx {
+            let code = &raw[code_start..close_idx];
+            let (language, header_path) = parse_code_block_header(header_line, code);
+            segments.push(MarkdownSegment::CodeBlock {
+                language,
+                header_path,
+                code: code.to_string(),
+            });
+            let after_close = close_idx + 3;
+            let next_pos = if after_close < raw.len() && raw.as_bytes()[after_close] == b'\n' {
+                after_close + 1
+            } else {
+                after_close
+            };
+            current_pos = next_pos;
+        } else {
+            let code = &raw[code_start..];
+            let (language, header_path) = parse_code_block_header(header_line, code);
+            segments.push(MarkdownSegment::CodeBlock {
+                language,
+                header_path,
+                code: code.to_string(),
+            });
+            return segments;
+        }
+    }
+
+    if current_pos < raw.len() {
+        let remainder = &raw[current_pos..];
+        if !remainder.is_empty() {
+            segments.push(MarkdownSegment::Markdown(remainder.to_string()));
+        }
+    }
+
+    if segments.is_empty() && !raw.is_empty() {
+        segments.push(MarkdownSegment::Markdown(raw.to_string()));
+    }
+
+    segments
+}
+
 struct MarkdownRenderState {
     source: String,
     state: Entity<TextViewState>,
@@ -2605,6 +2744,145 @@ impl ChatListView {
             })
     }
 
+    fn render_interactive_code_block(
+        &mut self,
+        msg_id: &str,
+        block_index: usize,
+        language: &str,
+        header_path: Option<&str>,
+        code: &str,
+        cx: &mut Context<Self>,
+    ) -> impl IntoElement {
+        let theme = cx.theme().colors;
+        let model = self.model.clone();
+        let code_str = code.to_string();
+        let copy_code = code.to_string();
+        let is_runnable = is_terminal_runnable_language(language);
+        let path_opt = header_path.map(str::to_string);
+        let path_for_open = path_opt.clone();
+
+        let display_lang = if language.trim().is_empty() {
+            "code"
+        } else {
+            language.trim()
+        };
+
+        div()
+            .w_full()
+            .my_2()
+            .rounded_lg()
+            .border_1()
+            .border_color(theme.border)
+            .bg(theme.title_bar)
+            .overflow_hidden()
+            .child(
+                div()
+                    .flex()
+                    .items_center()
+                    .justify_between()
+                    .px_3()
+                    .py_1p5()
+                    .bg(theme.secondary)
+                    .border_b_1()
+                    .border_color(theme.border)
+                    .child(
+                        div()
+                            .flex()
+                            .items_center()
+                            .gap_2()
+                            .min_w_0()
+                            .child(
+                                Tag::new()
+                                    .child(display_lang.to_string())
+                                    .with_variant(TagVariant::Secondary)
+                                    .small(),
+                            )
+                            .children(path_opt.map(|path| {
+                                div()
+                                    .text_xs()
+                                    .text_color(theme.muted_foreground)
+                                    .truncate()
+                                    .child(path)
+                            })),
+                    )
+                    .child(
+                        div()
+                            .flex()
+                            .items_center()
+                            .gap_1()
+                            .children(is_runnable.then(|| {
+                                let cmd = code_str.clone();
+                                let model = model.clone();
+                                Button::new(SharedString::from(format!(
+                                    "run-term-{msg_id}-{block_index}"
+                                )))
+                                .icon(IconName::SquareTerminal)
+                                .label("Run in Terminal")
+                                .xsmall()
+                                .secondary()
+                                .tooltip("Run in active project terminal")
+                                .on_click(move |_event, _window, cx| {
+                                    let cmd = cmd.clone();
+                                    model.update(cx, |state, cx| {
+                                        controller::dispatch(
+                                            state,
+                                            AppAction::RunTerminalCommand(cmd),
+                                        );
+                                        cx.notify();
+                                    });
+                                })
+                            }))
+                            .children(path_for_open.map(|path| {
+                                let model = model.clone();
+                                Button::new(SharedString::from(format!(
+                                    "open-edit-{msg_id}-{block_index}"
+                                )))
+                                .icon(IconName::File)
+                                .label("Open in Editor")
+                                .xsmall()
+                                .ghost()
+                                .tooltip("Open file in central editor")
+                                .on_click(move |_event, _window, cx| {
+                                    let path = path.clone();
+                                    model.update(cx, |state, cx| {
+                                        controller::dispatch(
+                                            state,
+                                            AppAction::OpenFileInEditor(path),
+                                        );
+                                        cx.notify();
+                                    });
+                                })
+                            }))
+                            .child(
+                                Button::new(SharedString::from(format!(
+                                    "copy-code-{msg_id}-{block_index}"
+                                )))
+                                .icon(IconName::Copy)
+                                .xsmall()
+                                .ghost()
+                                .tooltip("Copy code to clipboard")
+                                .on_click(move |_event, window, cx| {
+                                    cx.write_to_clipboard(ClipboardItem::new_string(
+                                        copy_code.clone(),
+                                    ));
+                                    window.push_notification(
+                                        Notification::info("Code copied to clipboard"),
+                                        cx,
+                                    );
+                                }),
+                            ),
+                    ),
+            )
+            .child(
+                div()
+                    .p_3()
+                    .font_family("monospace")
+                    .text_xs()
+                    .text_color(theme.foreground)
+                    .child(code.trim_end().to_string()),
+            )
+    }
+
     fn render_reasoning_block(
         &mut self,
         msg: &ChatMessageInfo,
@@ -2795,16 +3073,54 @@ impl ChatListView {
                             .gap_2()
                             .children(reasoning_element)
                             .children(if !msg.content.is_empty() {
-                                let content = div().w_full().text_sm().text_color(theme.foreground);
-                                Some(if msg.streaming {
-                                    content.child(msg.content.clone()).into_any_element()
-                                } else {
-                                    let markdown_state =
-                                        self.markdown_state(msg.id.clone(), &msg.content, cx);
-                                    content
-                                        .child(self.chat_markdown_view(&markdown_state))
-                                        .into_any_element()
-                                })
+                                let segments = extract_markdown_segments(&msg.content);
+                                let rendered_segments: Vec<AnyElement> = segments
+                                    .into_iter()
+                                    .enumerate()
+                                    .map(|(idx, seg)| match seg {
+                                        MarkdownSegment::Markdown(text) => {
+                                            if msg.streaming {
+                                                div()
+                                                    .w_full()
+                                                    .text_sm()
+                                                    .text_color(theme.foreground)
+                                                    .child(text)
+                                                    .into_any_element()
+                                            } else {
+                                                let markdown_state = self.markdown_state(
+                                                    format!("{}-seg-{}", msg.id, idx),
+                                                    &text,
+                                                    cx,
+                                                );
+                                                self.chat_markdown_view(&markdown_state)
+                                                    .into_any_element()
+                                            }
+                                        }
+                                        MarkdownSegment::CodeBlock {
+                                            language,
+                                            header_path,
+                                            code,
+                                        } => self
+                                            .render_interactive_code_block(
+                                                &msg.id,
+                                                idx,
+                                                &language,
+                                                header_path.as_deref(),
+                                                &code,
+                                                cx,
+                                            )
+                                            .into_any_element(),
+                                    })
+                                    .collect();
+
+                                Some(
+                                    div()
+                                        .w_full()
+                                        .flex()
+                                        .flex_col()
+                                        .gap_1()
+                                        .children(rendered_segments),
+                                )
                             } else {
                                 None
                             })
@@ -4685,11 +5001,12 @@ impl Render for ChatListView {
 mod hot_path_tests {
     use super::{
         ChatLinkTarget, ContextMeterContext, ContextMeterMetrics, MARKDOWN_CACHE_ENTRY_LIMIT,
-        MarkdownUpdate, TrajectoryCacheKey, TrajectoryMode, TrajectoryRow, TranscriptRow,
-        build_trajectory_rows, build_transcript_rows, classify_chat_link, classify_markdown_update,
-        contains_case_insensitive, context_meter_view_model, extend_trajectory_facets,
-        extend_trajectory_previews, extend_trajectory_rows, extend_trajectory_summary,
-        format_trajectory_raw_json, grouped_tool_activities, markdown_cache_exceeded,
+        MarkdownSegment, MarkdownUpdate, TrajectoryCacheKey, TrajectoryMode, TrajectoryRow,
+        TranscriptRow, build_trajectory_rows, build_transcript_rows, classify_chat_link,
+        classify_markdown_update, contains_case_insensitive, context_meter_view_model,
+        extend_trajectory_facets, extend_trajectory_previews, extend_trajectory_rows,
+        extend_trajectory_summary, extract_markdown_segments, format_trajectory_raw_json,
+        grouped_tool_activities, is_terminal_runnable_language, markdown_cache_exceeded,
         next_chat_stream_batch, reconcile_trajectory_entries,
         reconcile_trajectory_entries_by_epoch, subagent_popover_counts, summarize_trajectory,
     };
@@ -5316,5 +5633,66 @@ mod hot_path_tests {
         let mut changed = base.clone();
         changed.query = "provider".into();
         assert_ne!(base, changed);
+    }
+
+    #[test]
+    fn extract_markdown_segments_parses_mixed_content_with_paths() {
+        let input = "Here is the command:\n```bash\ncargo build --workspace\n```\nAnd code in file:\n```rust src/main.rs\n// src/main.rs\nfn main() {}\n```\nFinished!";
+        let segments = extract_markdown_segments(input);
+        assert_eq!(segments.len(), 5);
+        assert_eq!(
+            segments[0],
+            MarkdownSegment::Markdown("Here is the command:\n".into())
+        );
+        assert_eq!(
+            segments[1],
+            MarkdownSegment::CodeBlock {
+                language: "bash".into(),
+                header_path: None,
+                code: "cargo build --workspace\n".into(),
+            }
+        );
+        assert_eq!(
+            segments[2],
+            MarkdownSegment::Markdown("And code in file:\n".into())
+        );
+        assert_eq!(
+            segments[3],
+            MarkdownSegment::CodeBlock {
+                language: "rust".into(),
+                header_path: Some("src/main.rs".into()),
+                code: "// src/main.rs\nfn main() {}\n".into(),
+            }
+        );
+        assert_eq!(
+            segments[4],
+            MarkdownSegment::Markdown("Finished!".into())
+        );
+    }
+
+    #[test]
+    fn extract_markdown_segments_handles_comment_path_heuristic() {
+        let input = "```typescript\n// app/routes/index.tsx\nexport default function Home() {}\n```";
+        let segments = extract_markdown_segments(input);
+        assert_eq!(segments.len(), 1);
+        assert_eq!(
+            segments[0],
+            MarkdownSegment::CodeBlock {
+                language: "typescript".into(),
+                header_path: Some("app/routes/index.tsx".into()),
+                code: "// app/routes/index.tsx\nexport default function Home() {}\n".into(),
+            }
+        );
+    }
+
+    #[test]
+    fn terminal_runnable_language_identifies_shell_flavors() {
+        assert!(is_terminal_runnable_language("bash"));
+        assert!(is_terminal_runnable_language("sh"));
+        assert!(is_terminal_runnable_language("zsh"));
+        assert!(is_terminal_runnable_language("shell"));
+        assert!(!is_terminal_runnable_language("rust"));
+        assert!(!is_terminal_runnable_language("python"));
+        assert!(!is_terminal_runnable_language("json"));
     }
 }

--- a/crates/threadlane-gpui/src/screens/chat/view.rs
+++ b/crates/threadlane-gpui/src/screens/chat/view.rs
@@ -734,13 +734,11 @@ impl ChatListView {
             window,
             move |this, input_state, event: &InputEvent, window, cx| {
                 cx.notify();
-                if matches!(
-                    event,
-                    InputEvent::PressEnter {
-                        secondary: false,
-                        shift: false
-                    }
-                ) {
+                if let InputEvent::PressEnter {
+                    secondary,
+                    shift: false,
+                } = event
+                {
                     let text = input_state.read(cx).value().to_string();
                     let is_generating = model_clone.read(cx).is_generating;
                     if !text.trim().is_empty() || (!is_generating && !this.pasted_images.is_empty())
@@ -750,10 +748,15 @@ impl ChatListView {
                         } else {
                             std::mem::take(&mut this.pasted_images)
                         };
+                        let is_steer = *secondary;
                         model_clone.update(cx, |state, cx| {
                             if is_generating {
                                 controller::dispatch(state, AppAction::StageBusyMessage(text));
-                                controller::dispatch(state, AppAction::QueuePendingMessage);
+                                if is_steer {
+                                    controller::dispatch(state, AppAction::SteerPendingMessage);
+                                } else {
+                                    controller::dispatch(state, AppAction::QueuePendingMessage);
+                                }
                             } else {
                                 controller::dispatch(
                                     state,
@@ -871,6 +874,19 @@ impl ChatListView {
         if pasted > 0 {
             cx.notify();
         }
+    }
+
+    pub(crate) fn set_tab(&mut self, tab: CentralTab, cx: &mut Context<Self>) {
+        self.current_tab = tab;
+        cx.notify();
+    }
+
+    pub(crate) fn focus_composer(&mut self, window: &mut Window, cx: &mut Context<Self>) {
+        self.current_tab = CentralTab::Chat;
+        self.input_state.update(cx, |input, cx| {
+            input.focus(window, cx);
+        });
+        cx.notify();
     }
 
     pub(crate) fn set_composer_text(
@@ -2695,45 +2711,65 @@ impl ChatListView {
     fn render_message(&mut self, msg: &ChatMessageInfo, cx: &mut Context<Self>) -> AnyElement {
         let theme = cx.theme().colors;
         match msg.role {
-            MessageRole::User => div()
-                .w_full()
-                .min_w_0()
-                .flex()
-                .justify_end()
-                .my_2()
-                .px_4()
-                .child(
-                    div()
-                        .min_w_0()
-                        .max_w(px(USER_BUBBLE_MAX_WIDTH))
-                        .p_3()
-                        .rounded_lg()
-                        .bg(theme.secondary)
-                        .text_sm()
-                        .text_color(theme.secondary_foreground)
-                        .child({
-                            let markdown_state =
-                                self.markdown_state(msg.id.clone(), &msg.content, cx);
-                            self.chat_markdown_view(&markdown_state)
-                        })
-                        .context_menu({
-                            let content = msg.content.clone();
-                            move |menu, _window, _cx| {
-                                let text = content.clone();
-                                menu.item(PopupMenuItem::new("Copy Message").on_click(
-                                    move |_event, window, cx| {
-                                        cx.write_to_clipboard(ClipboardItem::new_string(
-                                            text.clone(),
-                                        ));
-                                        window.push_notification(
-                                            Notification::info("Copied to clipboard"),
-                                            cx,
-                                        );
-                                    },
-                                ))
-                            }
-                        }),
-                ),
+            MessageRole::User => {
+                let is_queued =
+                    msg.id.starts_with("queued-user-") && self.model.read(cx).is_generating;
+                div()
+                    .w_full()
+                    .min_w_0()
+                    .flex()
+                    .flex_col()
+                    .items_end()
+                    .my_2()
+                    .px_4()
+                    .when(is_queued, |el| {
+                        el.child(
+                            div()
+                                .flex()
+                                .items_center()
+                                .gap_1()
+                                .mb_1()
+                                .child(
+                                    Tag::new()
+                                        .child("Queued for next turn")
+                                        .with_variant(TagVariant::Secondary)
+                                        .small(),
+                                ),
+                        )
+                    })
+                    .child(
+                        div()
+                            .min_w_0()
+                            .max_w(px(USER_BUBBLE_MAX_WIDTH))
+                            .p_3()
+                            .rounded_lg()
+                            .bg(theme.secondary)
+                            .text_sm()
+                            .text_color(theme.secondary_foreground)
+                            .child({
+                                let markdown_state =
+                                    self.markdown_state(msg.id.clone(), &msg.content, cx);
+                                self.chat_markdown_view(&markdown_state)
+                            })
+                            .context_menu({
+                                let content = msg.content.clone();
+                                move |menu, _window, _cx| {
+                                    let text = content.clone();
+                                    menu.item(PopupMenuItem::new("Copy Message").on_click(
+                                        move |_event, window, cx| {
+                                            cx.write_to_clipboard(ClipboardItem::new_string(
+                                                text.clone(),
+                                            ));
+                                            window.push_notification(
+                                                Notification::info("Copied to clipboard"),
+                                                cx,
+                                            );
+                                        },
+                                    ))
+                                }
+                            }),
+                    )
+            }
             MessageRole::Assistant => {
                 let reasoning_element = self.render_reasoning_block(msg, cx);
                 let tool_elements: Vec<_> = msg
@@ -3487,8 +3523,6 @@ impl ChatListView {
 
     fn render_composer(&mut self, cx: &mut Context<Self>) -> impl IntoElement {
         let theme = cx.theme().colors;
-        let model = self.model.clone();
-        let input_state = self.input_state.clone();
         let (
             selected_model,
             reasoning_effort,
@@ -3564,6 +3598,13 @@ impl ChatListView {
         let steer_model = self.model.clone();
         let dismiss_model = self.model.clone();
         let dismiss_input = self.input_state.clone();
+        let cancel_model = self.model.clone();
+        let queue_prompt_model = self.model.clone();
+        let queue_prompt_input = self.input_state.clone();
+        let steer_prompt_model = self.model.clone();
+        let steer_prompt_input = self.input_state.clone();
+        let send_model = self.model.clone();
+        let send_input = self.input_state.clone();
 
         let image_chips = self
             .pasted_images
@@ -4306,60 +4347,128 @@ impl ChatListView {
                             .child(stash_button)
                             .children(subagent_popover)
                             .child(context_meter)
-                            .child(
-                                Button::new("send-btn")
-                                    .w(px(40.0))
-                                    .h(px(40.0))
-                                    .icon(if is_generating {
-                                        IconName::CircleX
-                                    } else {
-                                        IconName::ArrowUp
-                                    })
-                                    .tooltip(if is_generating {
-                                        "Stop generation (Esc)"
-                                    } else if needs_provider {
-                                        "Connect a model provider in Settings before sending"
-                                    } else if has_prompt {
-                                        "Send message (Enter)"
-                                    } else {
-                                        "Type a message to send"
-                                    })
-                                    .when(is_generating, |button| button.danger())
-                                    .when(!is_generating, |button| button.primary())
-                                    .disabled(!is_generating && (!has_prompt || needs_provider))
-                                    .on_click(cx.listener(move |this, _event, window, cx| {
-                                        if is_generating {
-                                            model.update(cx, |state, cx| {
-                                                controller::dispatch(
-                                                    state,
-                                                    AppAction::CancelGeneration,
-                                                );
+                            .children(if is_generating {
+                                if has_prompt {
+                                    vec![
+                                        Button::new("composer-queue-btn")
+                                            .icon(IconName::Plus)
+                                            .label("Queue")
+                                            .small()
+                                            .secondary()
+                                            .tooltip("Queue for next turn (Enter)")
+                                            .on_click(cx.listener(move |this, _event, window, cx| {
+                                                let text = queue_prompt_input.read(cx).value().to_string();
+                                                if !text.trim().is_empty() {
+                                                    queue_prompt_model.update(cx, |state, cx| {
+                                                        controller::dispatch(state, AppAction::StageBusyMessage(text));
+                                                        controller::dispatch(state, AppAction::QueuePendingMessage);
+                                                        cx.notify();
+                                                    });
+                                                    queue_prompt_input.update(cx, |state, cx| {
+                                                        state.set_value("", window, cx);
+                                                    });
+                                                    this.transcript_list_state.scroll_to_end();
+                                                    cx.notify();
+                                                }
+                                            }))
+                                            .into_any_element(),
+                                        Button::new("composer-steer-btn")
+                                            .icon(IconName::ArrowRight)
+                                            .label("Steer")
+                                            .small()
+                                            .primary()
+                                            .tooltip("Steer current turn immediately (Cmd+Enter)")
+                                            .on_click(cx.listener(move |this, _event, window, cx| {
+                                                let text = steer_prompt_input.read(cx).value().to_string();
+                                                if !text.trim().is_empty() {
+                                                    steer_prompt_model.update(cx, |state, cx| {
+                                                        controller::dispatch(state, AppAction::StageBusyMessage(text));
+                                                        controller::dispatch(state, AppAction::SteerPendingMessage);
+                                                        cx.notify();
+                                                    });
+                                                    steer_prompt_input.update(cx, |state, cx| {
+                                                        state.set_value("", window, cx);
+                                                    });
+                                                    this.transcript_list_state.scroll_to_end();
+                                                    cx.notify();
+                                                }
+                                            }))
+                                            .into_any_element(),
+                                        Button::new("composer-stop-btn")
+                                            .icon(IconName::CircleX)
+                                            .small()
+                                            .danger()
+                                            .tooltip("Stop generation (Esc)")
+                                            .on_click(cx.listener(move |_this, _event, _window, cx| {
+                                                cancel_model.update(cx, |state, cx| {
+                                                    controller::dispatch(
+                                                        state,
+                                                        AppAction::CancelGeneration,
+                                                    );
+                                                    cx.notify();
+                                                });
+                                            }))
+                                            .into_any_element(),
+                                    ]
+                                } else {
+                                    vec![
+                                        Button::new("send-btn")
+                                            .w(px(40.0))
+                                            .h(px(40.0))
+                                            .icon(IconName::CircleX)
+                                            .danger()
+                                            .tooltip("Stop generation (Esc)")
+                                            .on_click(cx.listener(move |_this, _event, _window, cx| {
+                                                cancel_model.update(cx, |state, cx| {
+                                                    controller::dispatch(
+                                                        state,
+                                                        AppAction::CancelGeneration,
+                                                    );
+                                                    cx.notify();
+                                                });
+                                            }))
+                                            .into_any_element(),
+                                    ]
+                                }
+                            } else {
+                                vec![
+                                    Button::new("send-btn")
+                                        .w(px(40.0))
+                                        .h(px(40.0))
+                                        .icon(IconName::ArrowUp)
+                                        .tooltip(if needs_provider {
+                                            "Connect a model provider in Settings before sending"
+                                        } else if has_prompt {
+                                            "Send message (Enter)"
+                                        } else {
+                                            "Type a message to send"
+                                        })
+                                        .primary()
+                                        .disabled(!has_prompt || needs_provider)
+                                        .on_click(cx.listener(move |this, _event, window, cx| {
+                                            let text = send_input.read(cx).value().to_string();
+                                            if !text.trim().is_empty() || !this.pasted_images.is_empty() {
+                                                let images = std::mem::take(&mut this.pasted_images);
+                                                send_model.update(cx, |state, cx| {
+                                                    controller::dispatch(
+                                                        state,
+                                                        AppAction::SendPromptWithImages {
+                                                            text,
+                                                            images,
+                                                        },
+                                                    );
+                                                    cx.notify();
+                                                });
+                                                send_input.update(cx, |state, cx| {
+                                                    state.set_value("", window, cx);
+                                                });
+                                                this.transcript_list_state.scroll_to_end();
                                                 cx.notify();
-                                            });
-                                            return;
-                                        }
-                                        let text = input_state.read(cx).value().to_string();
-                                        if !text.trim().is_empty() || !this.pasted_images.is_empty()
-                                        {
-                                            let images = std::mem::take(&mut this.pasted_images);
-                                            model.update(cx, |state, cx| {
-                                                controller::dispatch(
-                                                    state,
-                                                    AppAction::SendPromptWithImages {
-                                                        text,
-                                                        images,
-                                                    },
-                                                );
-                                                cx.notify();
-                                            });
-                                            input_state.update(cx, |state, cx| {
-                                                state.set_value("", window, cx);
-                                            });
-                                            this.transcript_list_state.scroll_to_end();
-                                            cx.notify();
-                                        }
-                                    })),
-                            ),
+                                            }
+                                        }))
+                                        .into_any_element(),
+                                ]
+                            }),
                     ),
             )
             .when(
@@ -4585,8 +4694,8 @@ mod hot_path_tests {
         reconcile_trajectory_entries_by_epoch, subagent_popover_counts, summarize_trajectory,
     };
     use crate::state::{
-        ChatMessageInfo, ChatStreamEvent, MessageRole, SubagentActivityStatus, ToolActivityInfo,
-        TrajectoryDiagnostics, TrajectoryEntry,
+        reported_session_shape_state, ChatMessageInfo, ChatStreamEvent, MessageRole,
+        SubagentActivityStatus, ToolActivityInfo, TrajectoryDiagnostics, TrajectoryEntry,
     };
 
     #[test]

--- a/crates/threadlane-gpui/src/screens/chat/view.rs
+++ b/crates/threadlane-gpui/src/screens/chat/view.rs
@@ -305,6 +305,35 @@ fn is_terminal_runnable_language(lang: &str) -> bool {
         "bash" | "sh" | "zsh" | "shell" | "terminal" | "console" | "cmd" | "powershell"
     )
 }
+
+fn active_shell_supports_language(lang: &str) -> bool {
+    let shell = std::env::var("SHELL")
+        .ok()
+        .and_then(|path| Path::new(&path).file_name().and_then(|name| name.to_str()).map(str::to_ascii_lowercase))
+        .unwrap_or_else(|| "sh".into());
+    match lang.trim().to_ascii_lowercase().as_str() {
+        "bash" => shell == "bash",
+        "zsh" => shell == "zsh",
+        "sh" => matches!(shell.as_str(), "sh" | "bash" | "zsh"),
+        "cmd" => matches!(shell.as_str(), "cmd" | "cmd.exe"),
+        "powershell" => matches!(shell.as_str(), "pwsh" | "powershell"),
+        "shell" | "terminal" | "console" => true,
+        _ => false,
+    }
+}
+
+fn normalize_terminal_command(command: &str) -> String {
+    command
+        .lines()
+        .map(|line| {
+            line.strip_prefix("$ ")
+                .or_else(|| line.strip_prefix(">>> "))
+                .or_else(|| line.strip_prefix("> "))
+                .unwrap_or(line)
+        })
+        .collect::<Vec<_>>()
+        .join("\n")
+}
 fn is_fence_line(raw: &str, idx: usize) -> bool {
     let line_start = raw[..idx].rfind('\n').map_or(0, |p| p + 1);
     raw[line_start..idx].len() <= 3 && raw[line_start..idx].bytes().all(|b| b == b' ')
@@ -336,10 +365,11 @@ fn parse_code_block_header(header: &str, code: &str) -> (String, Option<String>)
 
             if let Some(candidate) = comment_content {
                 let candidate = candidate.trim();
-                if (candidate.contains('/') || candidate.contains('.'))
+                if candidate.contains('/')
                     && !candidate.contains(' ')
                     && candidate.len() < 120
                     && !candidate.starts_with("http")
+                    && !candidate.starts_with('!')
                 {
                     detected_path = Some(candidate.to_string());
                 }
@@ -353,13 +383,13 @@ fn parse_code_block_header(header: &str, code: &str) -> (String, Option<String>)
 pub fn extract_markdown_segments(raw: &str) -> Vec<MarkdownSegment> {
     let mut segments = Vec::new();
     let mut current_pos = 0;
+    let mut search_from = 0;
 
-    while let Some(start_fence) = raw[current_pos..].find("```") {
-        let fence_start_idx = current_pos + start_fence;
+    while let Some(start_fence) = raw[search_from..].find("```") {
+        let fence_start_idx = search_from + start_fence;
 
-        let is_line_start = fence_start_idx == 0 || raw.as_bytes()[fence_start_idx - 1] == b'\n';
-        if !is_line_start {
-            current_pos = fence_start_idx + 3;
+        if !is_fence_line(raw, fence_start_idx) {
+            search_from = fence_start_idx + 3;
             continue;
         }
 
@@ -405,6 +435,7 @@ pub fn extract_markdown_segments(raw: &str) -> Vec<MarkdownSegment> {
                 after_close
             };
             current_pos = next_pos;
+            search_from = current_pos;
         } else {
             let code = &raw[code_start..];
             let (language, header_path) = parse_code_block_header(header_line, code);
@@ -2751,17 +2782,19 @@ impl ChatListView {
         language: &str,
         header_path: Option<&str>,
         code: &str,
+        streaming: bool,
         cx: &mut Context<Self>,
     ) -> impl IntoElement {
         let theme = cx.theme().colors;
         let model = self.model.clone();
         let code_str = code.to_string();
         let copy_code = code.to_string();
-        let is_runnable = is_terminal_runnable_language(language);
+        let is_runnable =
+            !streaming && is_terminal_runnable_language(language) && active_shell_supports_language(language);
         let path_opt = header_path.and_then(|path| match classify_chat_link(path) {
             ChatLinkTarget::ProjectFile(path) => Some(path), _ => None,
         });
-        let path_for_open = path_opt.clone();
+        let path_for_open = (!streaming).then(|| path_opt.clone()).flatten();
 
         let display_lang = if language.trim().is_empty() {
             "code"
@@ -2824,14 +2857,29 @@ impl ChatListView {
                                 .secondary()
                                 .tooltip("Run in active project terminal")
                                 .on_click(move |_event, _window, cx| {
-                                    let cmd = cmd.clone();
-                                    model.update(cx, |state, cx| {
-                                        controller::dispatch(
-                                            state,
-                                            AppAction::RunTerminalCommand(cmd),
-                                        );
-                                        cx.notify();
-                                    });
+                                    let cmd = normalize_terminal_command(&cmd);
+                                    if cmd.lines().filter(|line| !line.trim().is_empty()).count() > 1 {
+                                        let model = model.clone();
+                                        cx.spawn(async move |cx| {
+                                            let result = rfd::AsyncMessageDialog::new()
+                                                .set_title("Run multiple terminal commands?")
+                                                .set_description("This code block contains multiple commands. Run them in the active terminal?")
+                                                .set_buttons(rfd::MessageButtons::YesNo)
+                                                .show()
+                                                .await;
+                                            if matches!(result, rfd::MessageDialogResult::Yes) {
+                                                let _ = model.update(cx, |state, cx| {
+                                                    controller::dispatch(state, AppAction::RunTerminalCommand(cmd));
+                                                    cx.notify();
+                                                });
+                                            }
+                                        }).detach();
+                                    } else {
+                                        model.update(cx, |state, cx| {
+                                            controller::dispatch(state, AppAction::RunTerminalCommand(cmd));
+                                            cx.notify();
+                                        });
+                                    }
                                 })
                             }))
                             .children(path_for_open.map(|path| {
@@ -2855,33 +2903,42 @@ impl ChatListView {
                                     });
                                 })
                             }))
-                            .child(
-                                Button::new(SharedString::from(format!(
-                                    "copy-code-{msg_id}-{block_index}"
-                                )))
-                                .icon(IconName::Copy)
-                                .xsmall()
-                                .ghost()
-                                .tooltip("Copy code to clipboard")
-                                .on_click(move |_event, window, cx| {
-                                    cx.write_to_clipboard(ClipboardItem::new_string(
-                                        copy_code.clone(),
-                                    ));
-                                    window.push_notification(
-                                        Notification::info("Code copied to clipboard"),
-                                        cx,
-                                    );
-                                }),
-                            ),
+                            .when(!streaming, |actions| {
+                                actions.child(
+                                    Button::new(SharedString::from(format!(
+                                        "copy-code-{msg_id}-{block_index}"
+                                    )))
+                                    .icon(IconName::Copy)
+                                    .xsmall()
+                                    .ghost()
+                                    .tooltip("Copy code to clipboard")
+                                    .on_click(move |_event, window, cx| {
+                                        cx.write_to_clipboard(ClipboardItem::new_string(
+                                            copy_code.clone(),
+                                        ));
+                                        window.push_notification(
+                                            Notification::info("Code copied to clipboard"),
+                                            cx,
+                                        );
+                                    }),
+                                )
+                            }),
                     ),
             )
             .child(
                 div()
+                    .overflow_x_scrollbar()
                     .p_3()
                     .font_family("monospace")
                     .text_xs()
                     .text_color(theme.foreground)
-                    .child(code.trim_end().to_string()),
+                    .child(
+                        TextView::markdown(
+                            format!("code-{msg_id}-{block_index}"),
+                            format!("```{language}\n{}\n```", code.trim_end()),
+                        )
+                        .selectable(true),
+                    ),
             )
     }
 
@@ -3110,6 +3167,7 @@ impl ChatListView {
                                                 &language,
                                                 header_path.as_deref(),
                                                 &code,
+                                                msg.streaming,
                                                 cx,
                                             )
                                             .into_any_element(),
@@ -3876,6 +3934,7 @@ impl ChatListView {
             (state.active_session_metrics(), context_window)
         };
         let subagent_count = self.model.read(cx).active_subagents().len();
+        let has_composer_text = !self.input_state.read(cx).value().trim().is_empty();
         let has_prompt =
             !self.input_state.read(cx).value().trim().is_empty() || !self.pasted_images.is_empty();
         let (model_options, selected_option, project_root) = {
@@ -4667,13 +4726,13 @@ impl ChatListView {
                             .children(subagent_popover)
                             .child(context_meter)
                             .children(if is_generating {
-                                if has_prompt {
                                     vec![
                                         Button::new("composer-queue-btn")
                                             .icon(IconName::Plus)
                                             .label("Queue")
                                             .small()
                                             .secondary()
+                                            .disabled(!has_composer_text)
                                             .tooltip("Queue for next turn (Enter)")
                                             .on_click(cx.listener(move |this, _event, window, cx| {
                                                 let text = queue_prompt_input.read(cx).value().to_string();
@@ -4697,6 +4756,7 @@ impl ChatListView {
                                             .label("Steer")
                                             .small()
                                             .primary()
+                                            .disabled(!has_composer_text)
                                             .tooltip("Steer current turn immediately (Cmd+Enter)")
                                             .on_click(cx.listener(move |this, _event, window, cx| {
                                                 let text = steer_prompt_input.read(cx).value().to_string();
@@ -4731,26 +4791,6 @@ impl ChatListView {
                                             }))
                                             .into_any_element(),
                                     ]
-                                } else {
-                                    vec![
-                                        Button::new("send-btn")
-                                            .w(px(40.0))
-                                            .h(px(40.0))
-                                            .icon(IconName::CircleX)
-                                            .danger()
-                                            .tooltip("Stop generation (Esc)")
-                                            .on_click(cx.listener(move |_this, _event, _window, cx| {
-                                                cancel_model.update(cx, |state, cx| {
-                                                    controller::dispatch(
-                                                        state,
-                                                        AppAction::CancelGeneration,
-                                                    );
-                                                    cx.notify();
-                                                });
-                                            }))
-                                            .into_any_element(),
-                                    ]
-                                }
                             } else {
                                 vec![
                                     Button::new("send-btn")
@@ -5012,7 +5052,7 @@ mod hot_path_tests {
         extend_trajectory_facets, extend_trajectory_previews, extend_trajectory_rows,
         extend_trajectory_summary, extract_markdown_segments, format_trajectory_raw_json,
         grouped_tool_activities, is_terminal_runnable_language, markdown_cache_exceeded,
-        next_chat_stream_batch, reconcile_trajectory_entries,
+        next_chat_stream_batch, normalize_terminal_command, reconcile_trajectory_entries,
         reconcile_trajectory_entries_by_epoch, subagent_popover_counts, summarize_trajectory,
     };
     use crate::state::{
@@ -5691,9 +5731,28 @@ mod hot_path_tests {
     }
 
     #[test]
+    fn extract_markdown_segments_rejects_version_and_shebang_as_paths() {
+        for input in ["```sh\n#!/bin/sh\necho hi\n```", "```rust\n// v1.2\nfn main() {}\n```"] {
+            let segments = extract_markdown_segments(input);
+            assert!(matches!(segments.as_slice(), [MarkdownSegment::CodeBlock { header_path: None, .. }]));
+        }
+    }
+
+    #[test]
     fn extract_markdown_segments_accepts_indented_closing_fence() {
         let segments = extract_markdown_segments("```rust\nlet x = 1;\n  ```\nAfter");
         assert!(matches!(segments.as_slice(), [MarkdownSegment::CodeBlock { .. }, MarkdownSegment::Markdown(text)] if text == "After"));
+    }
+
+    #[test]
+    fn extract_markdown_segments_keeps_text_before_mid_line_backticks() {
+        let segments = extract_markdown_segments("Prefix ```inline\n```rust\ncode\n```");
+        assert!(matches!(segments.as_slice(), [MarkdownSegment::Markdown(text), MarkdownSegment::CodeBlock { language, .. }] if text == "Prefix ```inline\n" && language == "rust"));
+    }
+
+    #[test]
+    fn normalize_terminal_command_removes_prompt_markers() {
+        assert_eq!(normalize_terminal_command("$ echo one\n>>> echo two\n> echo three"), "echo one\necho two\necho three");
     }
 
     #[test]

--- a/crates/threadlane-gpui/src/screens/terminal/mod.rs
+++ b/crates/threadlane-gpui/src/screens/terminal/mod.rs
@@ -330,6 +330,13 @@ impl TerminalView {
         terminal
     }
 
+    /// Sends raw input bytes into the terminal PTY.
+    pub fn send_input(&self, input: &str) {
+        if let Some(session) = &self.session {
+            session.write(input.as_bytes());
+        }
+    }
+
     /// Switches the shell to another project, restarting it in the new cwd.
     pub fn set_project(&mut self, project: PathBuf, cx: &mut Context<Self>) {
         if self.project != project {

--- a/crates/threadlane-gpui/src/screens/workspace/view.rs
+++ b/crates/threadlane-gpui/src/screens/workspace/view.rs
@@ -266,12 +266,11 @@ impl WorkspaceView {
                     model.update(cx, |state, _cx| state.requested_terminal_command.take())
                 {
                     this.bottom_panel_visible = true;
-                    let work_dir = model
-                        .read(cx)
-                        .active_work_dir
-                        .clone()
-                        .unwrap_or_else(|| PathBuf::from("."));
-                    let term = this.get_or_create_active_terminal(&work_dir, cx);
+                    let term = if let Some(work_dir) = model.read(cx).active_work_dir.clone() {
+                        this.get_or_create_active_terminal(&work_dir, cx)
+                    } else {
+                        this.fallback_terminal(cx)
+                    };
                     term.update(cx, |term, _cx| {
                         let trimmed = cmd.trim_end();
                         term.send_input(&format!("{trimmed}\n"));
@@ -453,6 +452,15 @@ impl WorkspaceView {
         project: &PathBuf,
         cx: &mut Context<Self>,
     ) -> Entity<TerminalView> {
+        let group = self.get_or_create_terminal_group(project, cx);
+        group.tabs[group.active_tab].clone()
+    }
+
+    fn get_or_create_terminal_group(
+        &mut self,
+        project: &PathBuf,
+        cx: &mut Context<Self>,
+    ) -> &mut TerminalGroup {
         let group = self
             .terminal_groups
             .entry(project.clone())
@@ -466,8 +474,8 @@ impl WorkspaceView {
                 .push(cx.new(|cx| TerminalView::new(project.clone(), cx)));
             group.active_tab = 0;
         }
-        let active_tab = group.active_tab.min(group.tabs.len().saturating_sub(1));
-        group.tabs[active_tab].clone()
+        group.active_tab = group.active_tab.min(group.tabs.len().saturating_sub(1));
+        group
     }
 
     fn add_terminal_tab(&mut self, project: PathBuf, cx: &mut Context<Self>) {
@@ -1369,14 +1377,7 @@ impl Render for WorkspaceView {
         let terminal_project = self.model.read(cx).active_work_dir.clone();
         let (terminal_tabs, active_terminal_tab, active_terminal) =
             if let Some(project) = &terminal_project {
-                let group = self
-                    .terminal_groups
-                    .entry(project.clone())
-                    .or_insert_with(|| TerminalGroup {
-                        tabs: vec![cx.new(|cx| TerminalView::new(project.clone(), cx))],
-                        active_tab: 0,
-                    });
-                group.active_tab = group.active_tab.min(group.tabs.len().saturating_sub(1));
+                let group = self.get_or_create_terminal_group(project, cx);
                 (
                     group.tabs.clone(),
                     group.active_tab,

--- a/crates/threadlane-gpui/src/screens/workspace/view.rs
+++ b/crates/threadlane-gpui/src/screens/workspace/view.rs
@@ -260,8 +260,23 @@ impl WorkspaceView {
 
         let model_clone = model.clone();
         let view = cx.new(|cx| {
-            let sub = cx.observe(&model_clone, move |this: &mut Self, _model, cx| {
+            let sub = cx.observe(&model_clone, move |this: &mut Self, model, cx| {
                 this.sync_git_status_with_active_project(cx);
+                if let Some(cmd) =
+                    model.update(cx, |state, _cx| state.requested_terminal_command.take())
+                {
+                    this.bottom_panel_visible = true;
+                    let work_dir = model
+                        .read(cx)
+                        .active_work_dir
+                        .clone()
+                        .unwrap_or_else(|| PathBuf::from("."));
+                    let term = this.get_or_create_active_terminal(&work_dir, cx);
+                    term.update(cx, |term, _cx| {
+                        let trimmed = cmd.trim_end();
+                        term.send_input(&format!("{trimmed}\n"));
+                    });
+                }
                 let _ = model_wake_tx.send(());
                 cx.notify();
             });
@@ -431,6 +446,28 @@ impl WorkspaceView {
         });
         self.refresh_git_status(cx);
         cx.notify();
+    }
+
+    fn get_or_create_active_terminal(
+        &mut self,
+        project: &PathBuf,
+        cx: &mut Context<Self>,
+    ) -> Entity<TerminalView> {
+        let group = self
+            .terminal_groups
+            .entry(project.clone())
+            .or_insert_with(|| TerminalGroup {
+                tabs: vec![cx.new(|cx| TerminalView::new(project.clone(), cx))],
+                active_tab: 0,
+            });
+        if group.tabs.is_empty() {
+            group
+                .tabs
+                .push(cx.new(|cx| TerminalView::new(project.clone(), cx)));
+            group.active_tab = 0;
+        }
+        let active_tab = group.active_tab.min(group.tabs.len().saturating_sub(1));
+        group.tabs[active_tab].clone()
     }
 
     fn add_terminal_tab(&mut self, project: PathBuf, cx: &mut Context<Self>) {

--- a/crates/threadlane-gpui/src/screens/workspace/view.rs
+++ b/crates/threadlane-gpui/src/screens/workspace/view.rs
@@ -20,6 +20,10 @@ actions!(
         BeginNewTask,
         OpenSettings,
         CancelActiveGeneration,
+        SelectChatTab,
+        SelectTrajectoryTab,
+        SelectEditorTab,
+        FocusComposer,
     ]
 );
 use threadlane_git::GitStatus;
@@ -51,6 +55,14 @@ pub fn init(cx: &mut App) {
         KeyBinding::new("ctrl-j", ToggleTerminal, None),
         KeyBinding::new("cmd-n", BeginNewTask, None),
         KeyBinding::new("ctrl-n", BeginNewTask, None),
+        KeyBinding::new("cmd-1", SelectChatTab, None),
+        KeyBinding::new("ctrl-1", SelectChatTab, None),
+        KeyBinding::new("cmd-2", SelectTrajectoryTab, None),
+        KeyBinding::new("ctrl-2", SelectTrajectoryTab, None),
+        KeyBinding::new("cmd-3", SelectEditorTab, None),
+        KeyBinding::new("ctrl-3", SelectEditorTab, None),
+        KeyBinding::new("cmd-l", FocusComposer, None),
+        KeyBinding::new("ctrl-l", FocusComposer, None),
         KeyBinding::new("cmd-,", OpenSettings, None),
         KeyBinding::new("ctrl-,", OpenSettings, None),
         KeyBinding::new("escape", CancelActiveGeneration, None),
@@ -1268,6 +1280,50 @@ impl WorkspaceView {
             });
         }
     }
+
+    fn select_chat_tab_action(
+        &mut self,
+        _: &SelectChatTab,
+        _window: &mut Window,
+        cx: &mut Context<Self>,
+    ) {
+        self.chat_list.update(cx, |chat, cx| {
+            chat.set_tab(crate::screens::chat::CentralTab::Chat, cx);
+        });
+    }
+
+    fn select_trajectory_tab_action(
+        &mut self,
+        _: &SelectTrajectoryTab,
+        _window: &mut Window,
+        cx: &mut Context<Self>,
+    ) {
+        self.chat_list.update(cx, |chat, cx| {
+            chat.set_tab(crate::screens::chat::CentralTab::Trajectory, cx);
+        });
+    }
+
+    fn select_editor_tab_action(
+        &mut self,
+        _: &SelectEditorTab,
+        _window: &mut Window,
+        cx: &mut Context<Self>,
+    ) {
+        self.chat_list.update(cx, |chat, cx| {
+            chat.set_tab(crate::screens::chat::CentralTab::Editor, cx);
+        });
+    }
+
+    fn focus_composer_action(
+        &mut self,
+        _: &FocusComposer,
+        window: &mut Window,
+        cx: &mut Context<Self>,
+    ) {
+        self.chat_list.update(cx, |chat, cx| {
+            chat.focus_composer(window, cx);
+        });
+    }
 }
 
 impl Render for WorkspaceView {
@@ -1588,6 +1644,10 @@ impl Render for WorkspaceView {
             .on_action(cx.listener(Self::begin_new_task_action))
             .on_action(cx.listener(Self::open_settings_action))
             .on_action(cx.listener(Self::cancel_active_generation_action))
+            .on_action(cx.listener(Self::select_chat_tab_action))
+            .on_action(cx.listener(Self::select_trajectory_tab_action))
+            .on_action(cx.listener(Self::select_editor_tab_action))
+            .on_action(cx.listener(Self::focus_composer_action))
             .bg(theme.background)
             .child(view_with_status_bar)
             .children((workspace_page == WorkspacePage::Chat).then(|| {

--- a/crates/threadlane-gpui/src/state/app_state.rs
+++ b/crates/threadlane-gpui/src/state/app_state.rs
@@ -224,6 +224,12 @@ pub enum RequestedEditorTarget {
     },
 }
 
+#[derive(Clone, Debug)]
+struct PendingComposerMessage {
+    text: String,
+    images: Vec<ImageAttachment>,
+}
+
 #[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
 pub enum WorkspacePage {
     #[default]
@@ -263,8 +269,7 @@ pub struct AppState {
     pub(crate) is_generating: bool,
     composer_text: String,
     pub(crate) session_status: Option<String>,
-    pending_composer_messages: HashMap<String, String>,
-    pending_composer_images: HashMap<String, Vec<ImageAttachment>>,
+    pending_composer_messages: HashMap<String, PendingComposerMessage>,
     session_token_usage: HashMap<SessionProjectionKey, TokenUsage>,
     trajectory_by_session: HashMap<SessionProjectionKey, Vec<TrajectoryEntry>>,
     subagents_by_session: HashMap<SessionProjectionKey, Vec<SubagentActivityInfo>>,
@@ -979,7 +984,6 @@ impl AppState {
             composer_text: String::new(),
             session_status,
             pending_composer_messages: HashMap::new(),
-            pending_composer_images: HashMap::new(),
             session_token_usage: HashMap::new(),
             trajectory_by_session: HashMap::new(),
             subagents_by_session: HashMap::new(),
@@ -1271,11 +1275,31 @@ impl AppState {
     }
 
     pub(crate) fn request_open_file(&mut self, relative_path: String) {
-        let Some(root) = self.active_work_dir.as_deref() else { return };
-        let Ok(path) = threadlane_tools::validate_path_in_workspace(&relative_path, root) else { return };
-        let Ok(canonical_root) = root.canonicalize() else { return };
-        let Ok(relative) = path.strip_prefix(canonical_root) else { return };
-        self.requested_editor_target = Some(RequestedEditorTarget::File(relative.to_string_lossy().into_owned()));
+        let Some(root) = self.active_work_dir.clone() else { return };
+        let path = match threadlane_tools::validate_path_in_workspace(&relative_path, &root) {
+            Ok(path) => path,
+            Err(error) => {
+                self.session_status = Some(error);
+                return;
+            }
+        };
+        let canonical_root = match root.canonicalize() {
+            Ok(root) => root,
+            Err(error) => {
+                self.session_status = Some(format!("Invalid workspace root: {error}"));
+                return;
+            }
+        };
+        let relative = match path.strip_prefix(canonical_root) {
+            Ok(relative) => relative,
+            Err(error) => {
+                self.session_status = Some(format!("File is outside the workspace: {error}"));
+                return;
+            }
+        };
+        self.requested_editor_target = Some(RequestedEditorTarget::File(
+            relative.to_string_lossy().into_owned(),
+        ));
     }
 
     pub(crate) fn request_open_diff(
@@ -1476,7 +1500,6 @@ impl AppState {
         let session_file = self.session_file(work_dir, session_id);
         self.session_runtimes.remove(&session_file);
         self.pending_composer_messages.remove(session_id);
-        self.pending_composer_images.remove(session_id);
         self.acp_config_options.remove(session_id);
         if let Some(project) = self
             .projects
@@ -3557,7 +3580,7 @@ impl AppState {
         self.active_session_id
             .as_ref()
             .and_then(|session_id| self.pending_composer_messages.get(session_id))
-            .map(String::as_str)
+            .map(|message| message.text.as_str())
     }
 
     pub(crate) fn stage_busy_message(&mut self, text: String, images: Vec<ImageAttachment>) -> Result<(), String> {
@@ -3572,8 +3595,8 @@ impl AppState {
         if !self.is_generating {
             return Err("The session is no longer generating".into());
         }
-        self.pending_composer_messages.insert(session_id.clone(), text);
-        self.pending_composer_images.insert(session_id, images);
+        self.pending_composer_messages
+            .insert(session_id, PendingComposerMessage { text, images });
         Ok(())
     }
 
@@ -3583,7 +3606,6 @@ impl AppState {
             .work_handle
             .try_queue_follow_up_with_images(text.clone(), images)?;
         self.pending_composer_messages.remove(&session_id);
-        self.pending_composer_images.remove(&session_id);
         self.push_optimistic_follow_up(&session_id, text, "queued-user");
         self.session_status = Some("Message queued…".into());
         Ok(())
@@ -3595,7 +3617,6 @@ impl AppState {
             .work_handle
             .queue_steer_with_images(text.clone(), images)?;
         self.pending_composer_messages.remove(&session_id);
-        self.pending_composer_images.remove(&session_id);
         self.push_optimistic_follow_up(&session_id, text, "steered-user");
         self.session_status = Some("Steering current turn…".into());
         Ok(())
@@ -3604,7 +3625,6 @@ impl AppState {
     pub(crate) fn dismiss_pending_message(&mut self) {
         if let Some(session_id) = self.active_session_id.as_ref() {
             self.pending_composer_messages.remove(session_id);
-            self.pending_composer_images.remove(session_id);
         }
     }
 
@@ -3625,12 +3645,12 @@ impl AppState {
             .get(&session_file)
             .cloned()
             .ok_or_else(|| "Session runtime is unavailable".to_string())?;
-        let text = self
+        let pending = self
             .pending_composer_messages
             .get(&session_id)
             .cloned()
             .ok_or_else(|| "No pending composer message".to_string())?;
-        Ok((runtime, session_id.clone(), text, self.pending_composer_images.get(&session_id).cloned().unwrap_or_default()))
+        Ok((runtime, session_id, pending.text, pending.images))
     }
 
     fn push_optimistic_follow_up(&mut self, session_id: &str, text: String, prefix: &str) {

--- a/crates/threadlane-gpui/src/state/app_state.rs
+++ b/crates/threadlane-gpui/src/state/app_state.rs
@@ -264,6 +264,7 @@ pub struct AppState {
     composer_text: String,
     pub(crate) session_status: Option<String>,
     pending_composer_messages: HashMap<String, String>,
+    pending_composer_images: HashMap<String, Vec<ImageAttachment>>,
     session_token_usage: HashMap<SessionProjectionKey, TokenUsage>,
     trajectory_by_session: HashMap<SessionProjectionKey, Vec<TrajectoryEntry>>,
     subagents_by_session: HashMap<SessionProjectionKey, Vec<SubagentActivityInfo>>,
@@ -978,6 +979,7 @@ impl AppState {
             composer_text: String::new(),
             session_status,
             pending_composer_messages: HashMap::new(),
+            pending_composer_images: HashMap::new(),
             session_token_usage: HashMap::new(),
             trajectory_by_session: HashMap::new(),
             subagents_by_session: HashMap::new(),
@@ -1269,7 +1271,11 @@ impl AppState {
     }
 
     pub(crate) fn request_open_file(&mut self, relative_path: String) {
-        self.requested_editor_target = Some(RequestedEditorTarget::File(relative_path));
+        let Some(root) = self.active_work_dir.as_deref() else { return };
+        let Ok(path) = threadlane_tools::validate_path_in_workspace(&relative_path, root) else { return };
+        let Ok(canonical_root) = root.canonicalize() else { return };
+        let Ok(relative) = path.strip_prefix(canonical_root) else { return };
+        self.requested_editor_target = Some(RequestedEditorTarget::File(relative.to_string_lossy().into_owned()));
     }
 
     pub(crate) fn request_open_diff(
@@ -1470,6 +1476,7 @@ impl AppState {
         let session_file = self.session_file(work_dir, session_id);
         self.session_runtimes.remove(&session_file);
         self.pending_composer_messages.remove(session_id);
+        self.pending_composer_images.remove(session_id);
         self.acp_config_options.remove(session_id);
         if let Some(project) = self
             .projects
@@ -3553,7 +3560,7 @@ impl AppState {
             .map(String::as_str)
     }
 
-    pub(crate) fn stage_busy_message(&mut self, text: String) -> Result<(), String> {
+    pub(crate) fn stage_busy_message(&mut self, text: String, images: Vec<ImageAttachment>) -> Result<(), String> {
         let text = text.trim().to_string();
         if text.is_empty() {
             return Ok(());
@@ -3565,28 +3572,31 @@ impl AppState {
         if !self.is_generating {
             return Err("The session is no longer generating".into());
         }
-        self.pending_composer_messages.insert(session_id, text);
+        self.pending_composer_messages.insert(session_id.clone(), text);
+        self.pending_composer_images.insert(session_id, images);
         Ok(())
     }
 
     pub(crate) fn queue_pending_message(&mut self) -> Result<(), String> {
-        let (runtime, session_id, text) = self.pending_runtime_message()?;
+        let (runtime, session_id, text, images) = self.pending_runtime_message()?;
         runtime
             .work_handle
-            .try_queue_follow_up_with_images(text.clone(), Vec::new())?;
+            .try_queue_follow_up_with_images(text.clone(), images)?;
         self.pending_composer_messages.remove(&session_id);
-        self.push_optimistic_follow_up(&session_id, text);
+        self.pending_composer_images.remove(&session_id);
+        self.push_optimistic_follow_up(&session_id, text, "queued-user");
         self.session_status = Some("Message queued…".into());
         Ok(())
     }
 
     pub(crate) fn steer_pending_message(&mut self) -> Result<(), String> {
-        let (runtime, session_id, text) = self.pending_runtime_message()?;
+        let (runtime, session_id, text, images) = self.pending_runtime_message()?;
         runtime
             .work_handle
-            .queue_steer_with_images(text.clone(), Vec::new())?;
+            .queue_steer_with_images(text.clone(), images)?;
         self.pending_composer_messages.remove(&session_id);
-        self.push_optimistic_follow_up(&session_id, text);
+        self.pending_composer_images.remove(&session_id);
+        self.push_optimistic_follow_up(&session_id, text, "steered-user");
         self.session_status = Some("Steering current turn…".into());
         Ok(())
     }
@@ -3594,10 +3604,11 @@ impl AppState {
     pub(crate) fn dismiss_pending_message(&mut self) {
         if let Some(session_id) = self.active_session_id.as_ref() {
             self.pending_composer_messages.remove(session_id);
+            self.pending_composer_images.remove(session_id);
         }
     }
 
-    fn pending_runtime_message(&self) -> Result<(Arc<SessionRuntime>, String, String), String> {
+    fn pending_runtime_message(&self) -> Result<(Arc<SessionRuntime>, String, String, Vec<ImageAttachment>), String> {
         let session_id = self
             .active_session_id
             .clone()
@@ -3619,14 +3630,14 @@ impl AppState {
             .get(&session_id)
             .cloned()
             .ok_or_else(|| "No pending composer message".to_string())?;
-        Ok((runtime, session_id, text))
+        Ok((runtime, session_id.clone(), text, self.pending_composer_images.get(&session_id).cloned().unwrap_or_default()))
     }
 
-    fn push_optimistic_follow_up(&mut self, session_id: &str, text: String) {
+    fn push_optimistic_follow_up(&mut self, session_id: &str, text: String, prefix: &str) {
         if self.active_session_id.as_deref() == Some(session_id) {
             let new_len = self.messages.len();
             self.messages_mut().push(ChatMessageInfo {
-                id: format!("queued-user-{session_id}-{new_len}"),
+                id: format!("{prefix}-{session_id}-{new_len}"),
                 role: MessageRole::User,
                 content: text,
                 tool_activities: Vec::new(),

--- a/crates/threadlane-gpui/src/state/app_state.rs
+++ b/crates/threadlane-gpui/src/state/app_state.rs
@@ -296,6 +296,7 @@ pub struct AppState {
     pub(crate) update_notice_dismissed: bool,
     pub(crate) requested_editor_target: Option<RequestedEditorTarget>,
     pub(crate) requested_composer_prompt: Option<String>,
+    pub(crate) requested_terminal_command: Option<String>,
     stream_tx: tokio::sync::mpsc::UnboundedSender<ChatStreamEvent>,
     pub(crate) stream_rx: Option<tokio::sync::mpsc::UnboundedReceiver<ChatStreamEvent>>,
     session_refresh_tx: Sender<PathBuf>,
@@ -1000,6 +1001,7 @@ impl AppState {
             update_notice_dismissed: false,
             requested_editor_target: None,
             requested_composer_prompt: None,
+            requested_terminal_command: None,
             stream_tx,
             stream_rx: Some(stream_rx),
             session_refresh_tx,
@@ -1285,6 +1287,10 @@ impl AppState {
 
     pub(crate) fn request_composer_prompt(&mut self, prompt: String) {
         self.requested_composer_prompt = Some(prompt);
+    }
+
+    pub(crate) fn request_run_terminal_command(&mut self, command: String) {
+        self.requested_terminal_command = Some(command);
     }
 
     pub(crate) fn select_session(


### PR DESCRIPTION
Support Cmd/Ctrl tab selection and composer focus, and mark queued prompts while allowing secondary Enter to steer them.