### PR TITLE
Preserve session branches and scope pull requests by branch

### DIFF
--- a/.github/workflows/hotpath-comment.yml
+++ b/.github/workflows/hotpath-comment.yml
@@ -137,9 +137,10 @@ jobs:
             exit 1
           fi
           comment_id="$(
-            gh api --paginate --slurp \
+            gh api --paginate \
               "repos/$GITHUB_REPOSITORY/issues/$pr_number/comments" \
-              --jq 'add | map(select(.user.login == "github-actions[bot]" and (.body | contains("<!-- threadlane-hotpath-report -->")))) | last | .id // empty'
+              --jq 'map(select(.user.login == "github-actions[bot]" and (.body | contains("<!-- threadlane-hotpath-report -->")))) | .[].id' \
+              | tail -n 1
           )"
           if test -n "$comment_id"; then
             gh api --method PATCH \

--- a/crates/threadlane-git/src/lib.rs
+++ b/crates/threadlane-git/src/lib.rs
@@ -25,9 +25,11 @@ struct RepositoryMetadata {
 }
 
 type TimedCache<T> = HashMap<PathBuf, (Instant, T)>;
+type PrCacheKey = (PathBuf, String);
 
 static REPOSITORY_METADATA_CACHE: OnceLock<Mutex<TimedCache<RepositoryMetadata>>> = OnceLock::new();
-static PR_CACHE: OnceLock<Mutex<TimedCache<Option<GitHubPrInfo>>>> = OnceLock::new();
+static PR_CACHE: OnceLock<Mutex<HashMap<PrCacheKey, (Instant, Option<GitHubPrInfo>)>>> =
+    OnceLock::new();
 
 fn fresh_cache_value<T: Clone>(entry: &(Instant, T), now: Instant, ttl: Duration) -> Option<T> {
     (now.duration_since(entry.0) <= ttl).then(|| entry.1.clone())
@@ -37,6 +39,10 @@ fn repository_key(work_dir: &Path) -> PathBuf {
     work_dir
         .canonicalize()
         .unwrap_or_else(|_| work_dir.to_path_buf())
+}
+
+fn pr_cache_key(work_dir: &Path, branch: &str) -> PrCacheKey {
+    (repository_key(work_dir), branch.to_owned())
 }
 
 const GIT_FIELD_SEPARATOR: char = '\u{1f}';
@@ -937,11 +943,12 @@ pub fn parse_gh_pr_json(json_str: &str) -> Result<GitHubPrInfo, String> {
     })
 }
 
-fn inspect_pr_uncached(work_dir: &Path) -> Result<Option<GitHubPrInfo>, GitError> {
+fn inspect_pr_uncached(work_dir: &Path, branch: &str) -> Result<Option<GitHubPrInfo>, GitError> {
     let output = Command::new("gh")
         .args([
             "pr",
             "view",
+            branch,
             "--json",
             "number,title,url,state,isDraft,comments,statusCheckRollup,headRefName,baseRefName",
         ])
@@ -1006,7 +1013,17 @@ fn inspect_pr_uncached(work_dir: &Path) -> Result<Option<GitHubPrInfo>, GitError
 }
 
 pub fn inspect_pr(work_dir: &Path) -> Result<Option<GitHubPrInfo>, GitError> {
-    let key = repository_key(work_dir);
+    let Some(branch) = current_branch(work_dir)? else {
+        return Ok(None);
+    };
+    inspect_pr_for_branch(work_dir, &branch)
+}
+
+pub fn inspect_pr_for_branch(
+    work_dir: &Path,
+    branch: &str,
+) -> Result<Option<GitHubPrInfo>, GitError> {
+    let key = pr_cache_key(work_dir, branch);
     let now = Instant::now();
     let cache = PR_CACHE.get_or_init(|| Mutex::new(HashMap::new()));
     if let Some(info) = cache.lock().ok().and_then(|cache| {
@@ -1016,11 +1033,16 @@ pub fn inspect_pr(work_dir: &Path) -> Result<Option<GitHubPrInfo>, GitError> {
     }) {
         return Ok(info);
     }
-    let info = inspect_pr_uncached(work_dir)?;
+    let info = inspect_pr_uncached(work_dir, branch)?;
     if let Ok(mut cache) = cache.lock() {
         cache.insert(key, (now, info.clone()));
     }
     Ok(info)
+}
+
+pub fn current_branch(work_dir: &Path) -> Result<Option<String>, GitError> {
+    let branch = command(work_dir, &["branch", "--show-current"])?;
+    Ok((!branch.trim().is_empty()).then(|| branch.trim().to_owned()))
 }
 
 pub fn create_branch(work_dir: &Path, name: &str) -> Result<(), GitError> {
@@ -1530,6 +1552,16 @@ mod tests {
                 std::time::Duration::from_secs(30),
             ),
             None
+        );
+    }
+
+    #[test]
+    fn pr_cache_separates_branches_in_the_same_repository() {
+        let repository = Path::new("/tmp/project");
+
+        assert_ne!(
+            pr_cache_key(repository, "feature/one"),
+            pr_cache_key(repository, "feature/two")
         );
     }
 

--- a/crates/threadlane-gpui/src/screens/sidebar/view.rs
+++ b/crates/threadlane-gpui/src/screens/sidebar/view.rs
@@ -226,7 +226,35 @@ fn sidebar_fingerprint(state: &AppState, now: u64) -> u64 {
             pr.passing_checks.hash(&mut hasher);
         }
     }
+    let mut git_prs: Vec<_> = state.git_prs.iter().collect();
+    git_prs.sort_by(|left, right| left.0.cmp(right.0));
+    for ((work_dir, branch), pr) in git_prs {
+        work_dir.hash(&mut hasher);
+        branch.hash(&mut hasher);
+        if let Some(pr) = pr {
+            pr.number.hash(&mut hasher);
+            pr.state.hash(&mut hasher);
+            pr.is_draft.hash(&mut hasher);
+            pr.total_checks.hash(&mut hasher);
+            pr.failing_checks.hash(&mut hasher);
+            pr.pending_checks.hash(&mut hasher);
+            pr.passing_checks.hash(&mut hasher);
+            pr.comments_count.hash(&mut hasher);
+        }
+    }
     hasher.finish()
+}
+
+fn session_pr_info<'a>(
+    session: &SessionInfo,
+    prs: &'a std::collections::HashMap<
+        (std::path::PathBuf, String),
+        Option<threadlane_git::GitHubPrInfo>,
+    >,
+) -> Option<&'a threadlane_git::GitHubPrInfo> {
+    let branch = session.git_branch.as_ref()?;
+    prs.get(&(session.work_dir.clone(), branch.clone()))
+        .and_then(Option::as_ref)
 }
 
 impl SidebarView {
@@ -463,13 +491,7 @@ impl SidebarView {
             .map(|name| name.to_string_lossy().to_string())
             .unwrap_or_else(|| "Project".to_string());
 
-        let pr_info = self
-            .model
-            .read(cx)
-            .git_statuses
-            .get(&session.work_dir)
-            .and_then(|g| g.pr.as_ref())
-            .cloned();
+        let pr_info = session_pr_info(session, &self.model.read(cx).git_prs).cloned();
 
         let pr_meta = pr_info.map(|pr| {
             let state_upper = pr.state.to_uppercase();
@@ -1209,8 +1231,11 @@ impl SidebarView {
 mod tests {
     use super::{
         DateGroup, HistoryRow, flatten_history_groups, format_time_ago, same_history_row_identity,
+        session_pr_info,
     };
     use crate::state::{SessionHealth, SessionInfo};
+    use std::collections::HashMap;
+    use threadlane_git::GitHubPrInfo;
 
     fn session(id: &str) -> SessionInfo {
         SessionInfo {
@@ -1220,6 +1245,7 @@ mod tests {
             session_file: format!("/project/{id}.jsonl").into(),
             updated_at: 0,
             health: SessionHealth::Healthy,
+            git_branch: None,
         }
     }
 
@@ -1247,6 +1273,33 @@ mod tests {
         assert_eq!(format_time_ago(100, 100), "Just now");
         assert_eq!(format_time_ago(41, 100), "Just now");
         assert_eq!(format_time_ago(40, 100), "1m ago");
+    }
+
+    #[test]
+    fn sessions_in_one_project_use_their_own_branch_pr() {
+        let mut first = session("first");
+        first.git_branch = Some("feature/one".into());
+        let mut second = session("second");
+        second.git_branch = Some("feature/two".into());
+        let prs = HashMap::from([
+            (
+                (first.work_dir.clone(), "feature/one".into()),
+                Some(GitHubPrInfo {
+                    number: 11,
+                    ..Default::default()
+                }),
+            ),
+            (
+                (second.work_dir.clone(), "feature/two".into()),
+                Some(GitHubPrInfo {
+                    number: 22,
+                    ..Default::default()
+                }),
+            ),
+        ]);
+
+        assert_eq!(session_pr_info(&first, &prs).unwrap().number, 11);
+        assert_eq!(session_pr_info(&second, &prs).unwrap().number, 22);
     }
 }
 

--- a/crates/threadlane-gpui/src/screens/sidebar/view.rs
+++ b/crates/threadlane-gpui/src/screens/sidebar/view.rs
@@ -185,6 +185,20 @@ pub struct SidebarView {
     _subscriptions: Vec<Subscription>,
 }
 
+fn sidebar_session_fingerprint(session: &SessionInfo) -> u64 {
+    use std::hash::{Hash, Hasher};
+
+    let mut hasher = std::collections::hash_map::DefaultHasher::new();
+    session.id.hash(&mut hasher);
+    session.title.hash(&mut hasher);
+    session.work_dir.hash(&mut hasher);
+    session.session_file.hash(&mut hasher);
+    session.updated_at.hash(&mut hasher);
+    session.health.hash(&mut hasher);
+    session.git_branch.hash(&mut hasher);
+    hasher.finish()
+}
+
 /// Hash of every piece of `AppState` the sidebar renders. Streaming deltas
 /// mutate messages, plans, and usage without touching any of these fields, so
 /// an unchanged hash lets the observer skip `cx.notify()` entirely. The minute
@@ -201,12 +215,7 @@ fn sidebar_fingerprint(state: &AppState, now: u64) -> u64 {
         project.name.hash(&mut hasher);
         project.work_dir.hash(&mut hasher);
         for session in &project.sessions {
-            session.id.hash(&mut hasher);
-            session.title.hash(&mut hasher);
-            session.work_dir.hash(&mut hasher);
-            session.session_file.hash(&mut hasher);
-            session.updated_at.hash(&mut hasher);
-            session.health.hash(&mut hasher);
+            sidebar_session_fingerprint(session).hash(&mut hasher);
             state
                 .session_is_generating(&session.session_file)
                 .hash(&mut hasher);
@@ -1231,7 +1240,7 @@ impl SidebarView {
 mod tests {
     use super::{
         DateGroup, HistoryRow, flatten_history_groups, format_time_ago, same_history_row_identity,
-        session_pr_info,
+        session_pr_info, sidebar_session_fingerprint,
     };
     use crate::state::{SessionHealth, SessionInfo};
     use std::collections::HashMap;
@@ -1300,6 +1309,17 @@ mod tests {
 
         assert_eq!(session_pr_info(&first, &prs).unwrap().number, 11);
         assert_eq!(session_pr_info(&second, &prs).unwrap().number, 22);
+    }
+
+    #[test]
+    fn changing_a_session_branch_changes_the_sidebar_fingerprint() {
+        let mut item = session("session");
+        item.git_branch = Some("feature/one".into());
+        let first = sidebar_session_fingerprint(&item);
+
+        item.git_branch = Some("feature/two".into());
+
+        assert_ne!(first, sidebar_session_fingerprint(&item));
     }
 }
 

--- a/crates/threadlane-gpui/src/screens/workspace/view.rs
+++ b/crates/threadlane-gpui/src/screens/workspace/view.rs
@@ -136,6 +136,13 @@ fn active_project_git_status<'a>(
     active_work_dir.and_then(|work_dir| statuses.get(work_dir))
 }
 
+fn session_pr_target_is_active(
+    targets: &HashSet<(PathBuf, String)>,
+    target: &(PathBuf, String),
+) -> bool {
+    targets.contains(target)
+}
+
 pub struct WorkspaceView {
     model: Entity<AppState>,
     sidebar: Entity<SidebarView>,
@@ -676,17 +683,38 @@ impl WorkspaceView {
             .collect::<Vec<_>>();
         self.last_git_pr_targets = targets;
         for (work_dir, branch) in new_targets {
-            let tx = self.git_event_tx.clone();
-            std::thread::spawn(move || {
-                let result = threadlane_git::inspect_pr_for_branch(&work_dir, &branch)
-                    .map_err(|error| error.to_string());
-                let _ = tx.send(GitEvent::PrLoaded {
-                    work_dir,
-                    branch,
-                    result,
-                });
-            });
+            self.spawn_session_pr_refresh(work_dir, branch);
         }
+    }
+
+    fn spawn_session_pr_refresh(&self, work_dir: PathBuf, branch: String) {
+        let tx = self.git_event_tx.clone();
+        std::thread::spawn(move || {
+            let result = threadlane_git::inspect_pr_for_branch(&work_dir, &branch)
+                .map_err(|error| error.to_string());
+            let _ = tx.send(GitEvent::PrLoaded {
+                work_dir,
+                branch,
+                result,
+            });
+        });
+    }
+
+    fn schedule_session_pr_refresh(
+        target: (PathBuf, String),
+        cx: &mut Context<Self>,
+    ) {
+        cx.spawn(async move |this, cx| {
+            cx.background_executor()
+                .timer(std::time::Duration::from_secs(31))
+                .await;
+            let _ = this.update(cx, |this, _cx| {
+                if session_pr_target_is_active(&this.last_git_pr_targets, &target) {
+                    this.spawn_session_pr_refresh(target.0, target.1);
+                }
+            });
+        })
+        .detach();
     }
 
     fn refresh_git_status(&mut self, cx: &App) {
@@ -717,12 +745,14 @@ impl WorkspaceView {
                 branch,
                 result,
             } => {
+                let target = (work_dir.clone(), branch.clone());
                 if let Ok(pr) = result {
                     self.model.update(cx, |state, cx| {
                         state.git_prs.insert((work_dir, branch), pr);
                         cx.notify();
                     });
                 }
+                Self::schedule_session_pr_refresh(target, cx);
                 return;
             }
             GitEvent::Loaded { work_dir, result } => (work_dir, result),
@@ -1828,11 +1858,11 @@ impl Render for WorkspaceView {
 mod tests {
     use super::{
         GitEvent, WorkspacePumpEvent, active_project_git_status, git_result_matches_active,
-        next_workspace_event,
+        next_workspace_event, session_pr_target_is_active,
     };
     use crate::services::updater::UpdaterEvent;
     use crate::state::SessionInfo;
-    use std::collections::HashMap;
+    use std::collections::{HashMap, HashSet};
     use std::path::{Path, PathBuf};
     use threadlane_git::GitStatus;
 
@@ -1862,6 +1892,18 @@ mod tests {
 
         assert!(git_result_matches_active(active, active));
         assert!(!git_result_matches_active(stale, active));
+    }
+
+    #[test]
+    fn session_pr_refresh_stops_after_the_branch_is_no_longer_used() {
+        let target = (PathBuf::from("/projects/current"), "feature/one".to_string());
+        let targets = HashSet::from([target.clone()]);
+
+        assert!(session_pr_target_is_active(&targets, &target));
+        assert!(!session_pr_target_is_active(
+            &HashSet::new(),
+            &target
+        ));
     }
 
     #[tokio::test]

--- a/crates/threadlane-gpui/src/screens/workspace/view.rs
+++ b/crates/threadlane-gpui/src/screens/workspace/view.rs
@@ -1,4 +1,4 @@
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 use std::path::{Path, PathBuf};
 
 use gpui::*;
@@ -76,6 +76,11 @@ enum GitEvent {
         work_dir: PathBuf,
         result: Result<GitStatus, String>,
     },
+    PrLoaded {
+        work_dir: PathBuf,
+        branch: String,
+        result: Result<Option<threadlane_git::GitHubPrInfo>, String>,
+    },
 }
 
 enum WorkspacePumpEvent {
@@ -145,6 +150,7 @@ pub struct WorkspaceView {
     command_palette_open: bool,
     command_state: Entity<CommandState>,
     last_git_work_dir: Option<PathBuf>,
+    last_git_pr_targets: HashSet<(PathBuf, String)>,
     sidebar_resizable_state: Entity<ResizableState>,
     right_panel_resizable_state: Entity<ResizableState>,
     bottom_panel_resizable_state: Entity<ResizableState>,
@@ -367,6 +373,7 @@ impl WorkspaceView {
                 command_palette_open: false,
                 command_state,
                 last_git_work_dir: None,
+                last_git_pr_targets: HashSet::new(),
                 sidebar_resizable_state,
                 right_panel_resizable_state,
                 bottom_panel_resizable_state,
@@ -635,6 +642,7 @@ impl WorkspaceView {
     }
 
     fn sync_git_status_with_active_project(&mut self, cx: &App) {
+        self.sync_session_prs(cx);
         let active_work_dir = self.model.read(cx).active_work_dir.clone();
         if self.last_git_work_dir == active_work_dir {
             return;
@@ -644,6 +652,40 @@ impl WorkspaceView {
 
         if let Some(work_dir) = active_work_dir {
             self.spawn_git_status_refresh(work_dir);
+        }
+    }
+
+    fn sync_session_prs(&mut self, cx: &App) {
+        let targets = self
+            .model
+            .read(cx)
+            .projects
+            .iter()
+            .flat_map(|project| {
+                project.sessions.iter().filter_map(|session| {
+                    session
+                        .git_branch
+                        .as_ref()
+                        .map(|branch| (session.work_dir.clone(), branch.clone()))
+                })
+            })
+            .collect::<HashSet<_>>();
+        let new_targets = targets
+            .difference(&self.last_git_pr_targets)
+            .cloned()
+            .collect::<Vec<_>>();
+        self.last_git_pr_targets = targets;
+        for (work_dir, branch) in new_targets {
+            let tx = self.git_event_tx.clone();
+            std::thread::spawn(move || {
+                let result = threadlane_git::inspect_pr_for_branch(&work_dir, &branch)
+                    .map_err(|error| error.to_string());
+                let _ = tx.send(GitEvent::PrLoaded {
+                    work_dir,
+                    branch,
+                    result,
+                });
+            });
         }
     }
 
@@ -669,7 +711,22 @@ impl WorkspaceView {
     }
 
     fn apply_git_event(&mut self, event: GitEvent, cx: &mut Context<Self>) {
-        let GitEvent::Loaded { work_dir, result } = event;
+        let (work_dir, result) = match event {
+            GitEvent::PrLoaded {
+                work_dir,
+                branch,
+                result,
+            } => {
+                if let Ok(pr) = result {
+                    self.model.update(cx, |state, cx| {
+                        state.git_prs.insert((work_dir, branch), pr);
+                        cx.notify();
+                    });
+                }
+                return;
+            }
+            GitEvent::Loaded { work_dir, result } => (work_dir, result),
+        };
         let Some(active_work_dir) = self.model.read(cx).active_work_dir.clone() else {
             return;
         };
@@ -680,6 +737,11 @@ impl WorkspaceView {
         if let Ok(status) = &result {
             self.model.update(cx, |state, cx| {
                 state.git_statuses.insert(work_dir.clone(), status.clone());
+                if let Some(branch) = status.branch.as_ref() {
+                    state
+                        .git_prs
+                        .insert((work_dir.clone(), branch.clone()), status.pr.clone());
+                }
                 cx.notify();
             });
         }

--- a/crates/threadlane-gpui/src/services/chat.rs
+++ b/crates/threadlane-gpui/src/services/chat.rs
@@ -70,7 +70,33 @@ pub(crate) fn execute_prompt(
             stream_tx: task_stream_tx.clone(),
             error: None,
         };
+        let work_dir = task_runtime
+            .session_file
+            .parent()
+            .and_then(std::path::Path::parent)
+            .and_then(std::path::Path::parent)
+            .map(std::path::Path::to_path_buf);
+        let git_branch = match work_dir {
+            Some(work_dir) => tokio::task::spawn_blocking(move || {
+                threadlane_git::current_branch(&work_dir)
+            })
+            .await
+            .ok()
+            .and_then(Result::ok)
+            .flatten(),
+            None => None,
+        };
         let mut agent = task_runtime.agent.lock().await;
+        if let Some(branch) = git_branch {
+            if let Err(error) = agent.set_fact("git_branch", &branch) {
+                cleanup.error = Some(error.clone());
+                let _ = task_stream_tx.send(ChatStreamEvent::Agent {
+                    session_id: task_session_id,
+                    event: AgentEvent::AgentError { error },
+                });
+                return;
+            }
+        }
         agent.set_reasoning_effort(reasoning_effort).await;
         let mut events = agent.subscribe();
         let run_error = {

--- a/crates/threadlane-gpui/src/state/app_state.rs
+++ b/crates/threadlane-gpui/src/state/app_state.rs
@@ -30,6 +30,7 @@ pub struct SessionInfo {
     pub(crate) session_file: PathBuf,
     pub(crate) updated_at: u64,
     pub(crate) health: SessionHealth,
+    pub(crate) git_branch: Option<String>,
 }
 
 #[derive(Clone, Debug)]
@@ -289,6 +290,7 @@ pub struct AppState {
     pub(crate) pending_permissions: HashMap<String, threadlane_session::PermissionRequest>,
     pub(crate) pending_hydrations: Vec<SessionHydrationRequest>,
     pub(crate) git_statuses: HashMap<PathBuf, threadlane_git::GitStatus>,
+    pub(crate) git_prs: HashMap<(PathBuf, String), Option<threadlane_git::GitHubPrInfo>>,
 
     pub(crate) selected_model: String,
     pub(crate) model_roles: threadlane_session::ModelRoles,
@@ -402,6 +404,7 @@ fn discover_session_stubs_in_project(work_dir: &Path) -> Vec<SessionInfo> {
                 updated_at: file_mtime(&path),
                 session_file: path,
                 health: SessionHealth::Healthy,
+                git_branch: None,
             })
         })
         .collect::<Vec<_>>();
@@ -448,18 +451,21 @@ fn discover_sessions_in_project_cached(
                     .file_stem()
                     .map(|s| s.to_string_lossy().to_string())
                     .unwrap_or_else(|| "session".into());
-                let (title, health, updated_at) = match JsonlStore::open_read_only(&path) {
-                    Ok(store) => (
-                        extract_session_title(&store, &id),
-                        SessionHealth::Healthy,
-                        file_mtime(&path),
-                    ),
-                    Err(_) => (
-                        "Unreadable session".to_string(),
-                        SessionHealth::Warning,
-                        file_mtime(&path),
-                    ),
-                };
+                let (title, health, updated_at, git_branch) =
+                    match JsonlStore::open_read_only(&path) {
+                        Ok(store) => (
+                            extract_session_title(&store, &id),
+                            SessionHealth::Healthy,
+                            file_mtime(&path),
+                            store.facts().get("git_branch").cloned(),
+                        ),
+                        Err(_) => (
+                            "Unreadable session".to_string(),
+                            SessionHealth::Warning,
+                            file_mtime(&path),
+                            None,
+                        ),
+                    };
                 let info = SessionInfo {
                     id,
                     title,
@@ -467,6 +473,7 @@ fn discover_sessions_in_project_cached(
                     session_file: path.clone(),
                     updated_at,
                     health,
+                    git_branch,
                 };
                 cache.entries.insert(
                     path.clone(),
@@ -1017,6 +1024,7 @@ impl AppState {
             pending_permissions: HashMap::new(),
             pending_hydrations: Vec::new(),
             git_statuses: HashMap::new(),
+            git_prs: HashMap::new(),
         };
         if let (Some(session_id), Some(session_file)) = (
             state.active_session_id.clone(),
@@ -3910,6 +3918,27 @@ mod tests {
     }
 
     #[test]
+    fn session_discovery_restores_its_last_git_branch() {
+        let unique = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap()
+            .as_nanos();
+        let work_dir = std::env::temp_dir().join(format!("threadlane-session-branch-{unique}"));
+        let session_file = work_dir.join(".threadlane/sessions/session.jsonl");
+        std::fs::create_dir_all(session_file.parent().unwrap()).unwrap();
+        let mut store = JsonlStore::open(&session_file).unwrap();
+        store
+            .append_fact("main", "git_branch", "feature/session", None)
+            .unwrap();
+        drop(store);
+
+        let sessions = discover_sessions_in_project(&work_dir);
+
+        assert_eq!(sessions[0].git_branch.as_deref(), Some("feature/session"));
+        std::fs::remove_dir_all(work_dir).ok();
+    }
+
+    #[test]
     fn cache_hit_rounding_uses_wide_intermediates_at_u64_max() {
         let metrics = SessionMetricsInfo {
             cache_read_tokens: u64::MAX,
@@ -4523,6 +4552,7 @@ mod tests {
                 session_file: session_file.to_path_buf(),
                 updated_at: 0,
                 health: SessionHealth::Healthy,
+                git_branch: None,
             }],
             is_expanded: true,
         });
@@ -5419,6 +5449,7 @@ mod tests {
                 session_file: session_file.clone(),
                 updated_at: 0,
                 health: SessionHealth::Working,
+                git_branch: None,
             }],
             is_expanded: true,
         });


### PR DESCRIPTION
Fixes:  #111
## Summary
- Persist each session’s current Git branch as a session fact.
- Cache and display GitHub pull request data per repository and branch.
- Refresh branch-specific PR data for sessions in the workspace.
- Add coverage for branch-isolated PR caching and session branch restoration.

## Testing
- Added focused unit tests for branch-specific PR selection, cache keys, and session discovery.