### PR TITLE
Fix ACP model picker scrolling

### DIFF
--- a/crates/threadlane-gpui/src/screens/chat/view.rs
+++ b/crates/threadlane-gpui/src/screens/chat/view.rs
@@ -4744,7 +4744,7 @@ impl ChatListView {
             let menu = menu.check_side(gpui_component::Side::Right);
             let mut previous_provider = None;
             let menu = model_options.iter().cloned().fold(
-                menu.scrollable(true),
+                menu.max_h(px(320.0)).scrollable(true),
                 |menu, option| {
                     let menu = if previous_provider == Some(option.provider) {
                         menu


### PR DESCRIPTION
## Summary

The ACP model picker could display more models than fit in the popup viewport, but did not consistently provide a usable scrollable region.

This change sets an explicit maximum height on the model picker popup while preserving the existing vertical scrolling behavior, allowing users to access ACP models outside the visible area.

Closes #144

## Testing

- `cargo check -p threadlane-gpui`
- `git diff --check`

## Validation note

`cargo test -p threadlane-gpui --lib` was attempted but the linker terminated with `SIGBUS` in the environment.
