### PR TITLE
Add bulk discard actions to Git review panel

### DIFF
--- a/crates/threadlane-git/src/git.rs
+++ b/crates/threadlane-git/src/git.rs
@@ -117,14 +117,17 @@ pub(crate) fn parse_status(_work_dir: &Path, porcelain: &str) -> GitStatus {
         } else {
             line.get(3..).unwrap_or_default().trim()
         };
-        // With -z, rename/copy records are followed by the old path as a
-        // separate record; the first path is already the new path we display.
-        // The line-based fallback keeps the legacy test format readable.
-        if (index == 'R' || index == 'C' || worktree == 'R' || worktree == 'C')
-            && porcelain.contains('\0')
-        {
-            let _old_path = records.next();
-        }
+        let orig_path = if index == 'R' || index == 'C' || worktree == 'R' || worktree == 'C' {
+            if porcelain.contains('\0') {
+                records.next()
+            } else {
+                raw_path
+                    .split_once(" -> ")
+                    .map(|(old_p, _)| old_p.trim().to_string())
+            }
+        } else {
+            None
+        };
         let path = raw_path
             .rsplit_once(" -> ")
             .map(|(_, new_path)| new_path)
@@ -139,6 +142,7 @@ pub(crate) fn parse_status(_work_dir: &Path, porcelain: &str) -> GitStatus {
             };
             status.files.push(GitFile {
                 path,
+                orig_path,
                 status: status_code,
                 index_status: index,
                 worktree_status: worktree,
@@ -475,6 +479,7 @@ pub fn inspect_stash_files(work_dir: &Path, stash_index: usize) -> Vec<GitFile> 
             let char_status = *status_map.get(&path).unwrap_or(&'M');
             files.push(GitFile {
                 path: path.clone(),
+                orig_path: None,
                 status: char_status.to_string(),
                 index_status: char_status,
                 worktree_status: ' ',
@@ -608,6 +613,7 @@ pub fn inspect_commit_files(work_dir: &Path, sha: &str) -> Vec<GitFile> {
 
     let mut status_map = std::collections::HashMap::new();
     let mut rename_destinations = std::collections::HashMap::new();
+    let mut rename_sources = std::collections::HashMap::new();
     for line in name_status_output.lines() {
         let parts: Vec<&str> = line.split('\t').collect();
         if let (Some(code), Some(path)) = (parts.first(), parts.get(1)) {
@@ -618,6 +624,7 @@ pub fn inspect_commit_files(work_dir: &Path, sha: &str) -> Vec<GitFile> {
                     let destination = destination.trim().to_string();
                     rename_destinations
                         .insert(format!("{source} => {destination}"), destination.clone());
+                    rename_sources.insert(destination.clone(), source);
                     status_map.insert(destination, status);
                 }
             } else {
@@ -640,6 +647,7 @@ pub fn inspect_commit_files(work_dir: &Path, sha: &str) -> Vec<GitFile> {
             let char_status = *status_map.get(&path).unwrap_or(&'M');
             files.push(GitFile {
                 path: path.clone(),
+                orig_path: rename_sources.get(&path).cloned(),
                 status: char_status.to_string(),
                 index_status: char_status,
                 worktree_status: ' ',
@@ -665,8 +673,35 @@ pub fn diff_commit_file(work_dir: &Path, sha: &str, file_path: &str) -> Result<S
     command(work_dir, &["show", sha, "--", file_path])
 }
 
+fn find_rename_source(work_dir: &Path, destination_path: &str) -> Option<String> {
+    let porcelain = command(work_dir, &["status", "--porcelain=v1", "-z"]).ok()?;
+    let mut records = porcelain.split('\0').filter(|r| !r.is_empty());
+    while let Some(line) = records.next() {
+        let bytes = line.as_bytes();
+        if bytes.len() < 3 {
+            continue;
+        }
+        let index = bytes[0] as char;
+        let worktree = bytes[1] as char;
+        let is_rename = index == 'R' || index == 'C' || worktree == 'R' || worktree == 'C';
+        let path = line.get(3..).unwrap_or_default();
+        if is_rename {
+            let old_path = records.next();
+            if path == destination_path {
+                return old_path.map(|s| s.to_string());
+            }
+        }
+    }
+    None
+}
+
 pub fn discard_file_changes(work_dir: &Path, relative_path: &str) -> Result<(), GitError> {
     validate_diff_path(work_dir, relative_path)?;
+    let rename_source = find_rename_source(work_dir, relative_path);
+    if let Some(ref old_path) = rename_source {
+        validate_diff_path(work_dir, old_path)?;
+    }
+
     let full_path = work_dir.join(relative_path);
     let in_index = command(work_dir, &["ls-files", "--error-unmatch", relative_path]).is_ok();
     if in_index {
@@ -687,6 +722,19 @@ pub fn discard_file_changes(work_dir: &Path, relative_path: &str) -> Result<(), 
         }
         let _ = command(work_dir, &["clean", "-f", "-d", "--", relative_path]);
     }
+
+    if let Some(old_path) = rename_source {
+        if command(
+            work_dir,
+            &["restore", "--staged", "--worktree", "--", &old_path],
+        )
+        .is_err()
+        {
+            let _ = command(work_dir, &["reset", "HEAD", "--", &old_path]);
+            let _ = command(work_dir, &["checkout", "HEAD", "--", &old_path]);
+        }
+    }
+
     Ok(())
 }
 
@@ -701,9 +749,12 @@ pub fn discard_files<S: AsRef<str>>(work_dir: &Path, relative_paths: &[S]) -> Re
 }
 
 pub fn discard_all_changes(work_dir: &Path) -> Result<(), GitError> {
-    let status = inspect(work_dir)?;
-    let paths: Vec<String> = status.files.into_iter().map(|f| f.path).collect();
-    discard_files(work_dir, &paths)
+    if command(work_dir, &["restore", "--staged", "--worktree", "."]).is_err() {
+        let _ = command(work_dir, &["reset", "HEAD", "."]);
+        let _ = command(work_dir, &["checkout", "HEAD", "."]);
+    }
+    let _ = command(work_dir, &["clean", "-f", "-d"]);
+    Ok(())
 }
 
 pub fn ignore_file(work_dir: &Path, relative_path: &str) -> Result<(), GitError> {

--- a/crates/threadlane-git/src/git.rs
+++ b/crates/threadlane-git/src/git.rs
@@ -690,6 +690,22 @@ pub fn discard_file_changes(work_dir: &Path, relative_path: &str) -> Result<(), 
     Ok(())
 }
 
+pub fn discard_files<S: AsRef<str>>(work_dir: &Path, relative_paths: &[S]) -> Result<(), GitError> {
+    for path in relative_paths {
+        validate_diff_path(work_dir, path.as_ref())?;
+    }
+    for path in relative_paths {
+        discard_file_changes(work_dir, path.as_ref())?;
+    }
+    Ok(())
+}
+
+pub fn discard_all_changes(work_dir: &Path) -> Result<(), GitError> {
+    let status = inspect(work_dir)?;
+    let paths: Vec<String> = status.files.into_iter().map(|f| f.path).collect();
+    discard_files(work_dir, &paths)
+}
+
 pub fn ignore_file(work_dir: &Path, relative_path: &str) -> Result<(), GitError> {
     validate_diff_path(work_dir, relative_path)?;
     let gitignore_path = work_dir.join(".gitignore");

--- a/crates/threadlane-git/src/tests.rs
+++ b/crates/threadlane-git/src/tests.rs
@@ -998,6 +998,63 @@ fn file_discard_and_ignore_lifecycle() {
 }
 
 #[test]
+fn discard_multiple_files_and_all_changes() {
+    let dir = tempdir().unwrap();
+    run_git(dir.path(), &["init", "-b", "main"]);
+    run_git(dir.path(), &["config", "user.email", "test@example.com"]);
+    run_git(dir.path(), &["config", "user.name", "Test"]);
+    fs::write(dir.path().join("tracked1.txt"), "t1 original\n").unwrap();
+    fs::write(dir.path().join("tracked2.txt"), "t2 original\n").unwrap();
+    fs::write(dir.path().join("tracked3.txt"), "t3 original\n").unwrap();
+    run_git(dir.path(), &["add", "."]);
+    run_git(dir.path(), &["commit", "-qm", "initial commit"]);
+
+    // Test rejection of path outside workspace in discard_files
+    assert!(discard_files(dir.path(), &["tracked1.txt", "../outside.txt"]).is_err());
+
+    // 1. Modify multiple tracked files and create untracked, discard specific subset
+    fs::write(dir.path().join("tracked1.txt"), "t1 modified\n").unwrap();
+    fs::write(dir.path().join("tracked2.txt"), "t2 modified\n").unwrap();
+    fs::write(dir.path().join("untracked1.txt"), "u1 content\n").unwrap();
+    fs::write(dir.path().join("untracked2.txt"), "u2 content\n").unwrap();
+    assert_eq!(inspect(dir.path()).unwrap().files.len(), 4);
+
+    // Discard tracked1 and untracked1
+    discard_files(dir.path(), &["tracked1.txt", "untracked1.txt"]).unwrap();
+    let status = inspect(dir.path()).unwrap();
+    assert_eq!(status.files.len(), 2);
+    assert_eq!(
+        fs::read_to_string(dir.path().join("tracked1.txt")).unwrap(),
+        "t1 original\n"
+    );
+    assert!(!dir.path().join("untracked1.txt").exists());
+    assert_eq!(
+        fs::read_to_string(dir.path().join("tracked2.txt")).unwrap(),
+        "t2 modified\n"
+    );
+    assert!(dir.path().join("untracked2.txt").exists());
+
+    // 2. Discard all remaining changes
+    discard_all_changes(dir.path()).unwrap();
+    assert_eq!(inspect(dir.path()).unwrap().files.len(), 0);
+    assert_eq!(
+        fs::read_to_string(dir.path().join("tracked2.txt")).unwrap(),
+        "t2 original\n"
+    );
+    assert!(!dir.path().join("untracked2.txt").exists());
+
+    // 3. Test with deletions and staged additions
+    fs::remove_file(dir.path().join("tracked3.txt")).unwrap();
+    fs::write(dir.path().join("new_staged.txt"), "staged\n").unwrap();
+    run_git(dir.path(), &["add", "new_staged.txt"]);
+    assert_eq!(inspect(dir.path()).unwrap().files.len(), 2);
+    discard_all_changes(dir.path()).unwrap();
+    assert_eq!(inspect(dir.path()).unwrap().files.len(), 0);
+    assert!(dir.path().join("tracked3.txt").exists());
+    assert!(!dir.path().join("new_staged.txt").exists());
+}
+
+#[test]
 fn commit_history_inspection() {
     let dir = tempdir().unwrap();
     run_git(dir.path(), &["init", "-b", "main"]);

--- a/crates/threadlane-git/src/tests.rs
+++ b/crates/threadlane-git/src/tests.rs
@@ -1052,6 +1052,26 @@ fn discard_multiple_files_and_all_changes() {
     assert_eq!(inspect(dir.path()).unwrap().files.len(), 0);
     assert!(dir.path().join("tracked3.txt").exists());
     assert!(!dir.path().join("new_staged.txt").exists());
+
+    // 4. Test staged rename discard preserves both paths
+    run_git(dir.path(), &["mv", "tracked1.txt", "renamed1.txt"]);
+    let status = inspect(dir.path()).unwrap();
+    assert_eq!(status.files.len(), 1);
+    assert_eq!(status.files[0].path, "renamed1.txt");
+    assert_eq!(status.files[0].orig_path.as_deref(), Some("tracked1.txt"));
+
+    discard_file_changes(dir.path(), "renamed1.txt").unwrap();
+    assert_eq!(inspect(dir.path()).unwrap().files.len(), 0);
+    assert!(dir.path().join("tracked1.txt").exists());
+    assert!(!dir.path().join("renamed1.txt").exists());
+
+    // 5. Test staged rename discard via discard_all_changes
+    run_git(dir.path(), &["mv", "tracked2.txt", "renamed2.txt"]);
+    assert_eq!(inspect(dir.path()).unwrap().files.len(), 1);
+    discard_all_changes(dir.path()).unwrap();
+    assert_eq!(inspect(dir.path()).unwrap().files.len(), 0);
+    assert!(dir.path().join("tracked2.txt").exists());
+    assert!(!dir.path().join("renamed2.txt").exists());
 }
 
 #[test]

--- a/crates/threadlane-git/src/types.rs
+++ b/crates/threadlane-git/src/types.rs
@@ -237,6 +237,8 @@ pub struct GitStatus {
 #[derive(Clone, Debug, Default, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
 pub struct GitFile {
     pub path: String,
+    #[serde(default)]
+    pub orig_path: Option<String>,
     pub(crate) status: String,
     pub(crate) index_status: char,
     pub(crate) worktree_status: char,

--- a/crates/threadlane-gpui/src/screens/right_panel/tests.rs
+++ b/crates/threadlane-gpui/src/screens/right_panel/tests.rs
@@ -440,3 +440,31 @@ fn selection_bar_discard_options_scenarios() {
     assert_eq!(opts5_none, vec![DiscardOption::All(5)]);
     assert_eq!(opts5_none[0].label(), "Discard All Changes (5)...");
 }
+
+#[test]
+fn discard_option_confirmation_and_action() {
+    let single = DiscardOption::Single("src/foo.rs".to_string());
+    assert!(!single.requires_confirmation());
+    assert_eq!(single.confirmation_prompt(), None);
+    assert_eq!(
+        single.git_action(),
+        GitAction::DiscardFile("src/foo.rs".to_string())
+    );
+
+    let selected = DiscardOption::Selected(vec!["src/a.rs".into(), "src/b.rs".into()]);
+    assert!(selected.requires_confirmation());
+    let prompt = selected.confirmation_prompt().unwrap();
+    assert_eq!(prompt.0, "Discard selected changes?");
+    assert!(prompt.1.contains("2 selected files"));
+    assert_eq!(
+        selected.git_action(),
+        GitAction::DiscardFiles(vec!["src/a.rs".into(), "src/b.rs".into()])
+    );
+
+    let all = DiscardOption::All(4);
+    assert!(all.requires_confirmation());
+    let prompt_all = all.confirmation_prompt().unwrap();
+    assert_eq!(prompt_all.0, "Discard all changes?");
+    assert!(prompt_all.1.contains("4 files"));
+    assert_eq!(all.git_action(), GitAction::DiscardAll);
+}

--- a/crates/threadlane-gpui/src/screens/right_panel/tests.rs
+++ b/crates/threadlane-gpui/src/screens/right_panel/tests.rs
@@ -8,7 +8,8 @@ use super::draft_pr::{
     DraftPrRemoteResult,
 };
 use super::types::{
-    can_create_pull_request, can_publish_branch, message_generated_matches_active_project,
+    can_create_pull_request, can_publish_branch, discard_options, message_generated_matches_active_project,
+    selection_bar_discard_options, DiscardOption,
 };
 use super::view::{retain_review_selection, scan_project_tree};
 
@@ -340,4 +341,102 @@ fn project_scan_is_bounded_and_skips_generated_roots() {
         .any(|item| item.relative_path == "src/nested"));
 
     std::fs::remove_dir_all(root).unwrap();
+}
+
+#[test]
+fn discard_options_for_single_file() {
+    let selected = vec!["src/a.rs".to_string()];
+    let options = discard_options("src/a.rs", &selected, 1);
+    assert_eq!(options, vec![DiscardOption::Single("src/a.rs".to_string())]);
+    assert_eq!(options[0].label(), "Discard Changes...");
+}
+
+#[test]
+fn discard_options_when_all_files_selected() {
+    let selected = vec![
+        "src/a.rs".to_string(),
+        "src/b.rs".to_string(),
+        "src/c.rs".to_string(),
+    ];
+    let options = discard_options("src/a.rs", &selected, 3);
+    assert_eq!(
+        options,
+        vec![
+            DiscardOption::Single("src/a.rs".to_string()),
+            DiscardOption::All(3),
+        ]
+    );
+    assert_eq!(options[0].label(), "Discard Changes...");
+    assert_eq!(options[1].label(), "Discard All Changes (3)...");
+}
+
+#[test]
+fn discard_options_when_subset_of_files_selected() {
+    let selected = vec!["src/a.rs".to_string(), "src/b.rs".to_string()];
+    let options = discard_options("src/c.rs", &selected, 5);
+    assert_eq!(
+        options,
+        vec![
+            DiscardOption::Single("src/c.rs".to_string()),
+            DiscardOption::Selected(vec!["src/a.rs".to_string(), "src/b.rs".to_string()]),
+            DiscardOption::All(5),
+        ]
+    );
+    assert_eq!(options[0].label(), "Discard Changes...");
+    assert_eq!(options[1].label(), "Discard Selected Changes (2)...");
+    assert_eq!(options[2].label(), "Discard All Changes (5)...");
+}
+
+#[test]
+fn discard_options_when_no_files_selected() {
+    let selected: Vec<String> = Vec::new();
+    let options = discard_options("src/a.rs", &selected, 4);
+    assert_eq!(
+        options,
+        vec![
+            DiscardOption::Single("src/a.rs".to_string()),
+            DiscardOption::All(4),
+        ]
+    );
+    assert_eq!(options[0].label(), "Discard Changes...");
+    assert_eq!(options[1].label(), "Discard All Changes (4)...");
+}
+
+#[test]
+fn selection_bar_discard_options_scenarios() {
+    // 0 files: empty
+    assert!(selection_bar_discard_options(&[], 0).is_empty());
+
+    // 1 file, 1 selected
+    let opts1 = selection_bar_discard_options(&["src/a.rs".to_string()], 1);
+    assert_eq!(opts1, vec![DiscardOption::All(1)]);
+    assert_eq!(opts1[0].label(), "Discard All Changes (1)...");
+
+    // 3 files, all selected
+    let all3 = vec![
+        "src/a.rs".to_string(),
+        "src/b.rs".to_string(),
+        "src/c.rs".to_string(),
+    ];
+    let opts3 = selection_bar_discard_options(&all3, 3);
+    assert_eq!(opts3, vec![DiscardOption::All(3)]);
+    assert_eq!(opts3[0].label(), "Discard All Changes (3)...");
+
+    // 5 files, 2 selected
+    let sub2 = vec!["src/a.rs".to_string(), "src/b.rs".to_string()];
+    let opts5 = selection_bar_discard_options(&sub2, 5);
+    assert_eq!(
+        opts5,
+        vec![
+            DiscardOption::Selected(vec!["src/a.rs".to_string(), "src/b.rs".to_string()]),
+            DiscardOption::All(5),
+        ]
+    );
+    assert_eq!(opts5[0].label(), "Discard Selected Changes (2)...");
+    assert_eq!(opts5[1].label(), "Discard All Changes (5)...");
+
+    // 5 files, 0 selected
+    let opts5_none = selection_bar_discard_options(&[], 5);
+    assert_eq!(opts5_none, vec![DiscardOption::All(5)]);
+    assert_eq!(opts5_none[0].label(), "Discard All Changes (5)...");
 }

--- a/crates/threadlane-gpui/src/screens/right_panel/types.rs
+++ b/crates/threadlane-gpui/src/screens/right_panel/types.rs
@@ -177,6 +177,43 @@ impl DiscardOption {
             Self::All(count) => format!("Discard All Changes ({count})..."),
         }
     }
+
+    pub fn git_action(&self) -> GitAction {
+        match self {
+            Self::Single(path) => GitAction::DiscardFile(path.clone()),
+            Self::Selected(paths) => GitAction::DiscardFiles(paths.clone()),
+            Self::All(_) => GitAction::DiscardAll,
+        }
+    }
+
+    pub fn requires_confirmation(&self) -> bool {
+        matches!(self, Self::Selected(_) | Self::All(_))
+    }
+
+    pub fn confirmation_prompt(&self) -> Option<(String, String)> {
+        match self {
+            Self::Single(_) => None,
+            Self::Selected(paths) => {
+                let count = paths.len();
+                let file_str = if count == 1 { "file" } else { "files" };
+                Some((
+                    "Discard selected changes?".to_string(),
+                    format!(
+                        "Are you sure you want to discard changes in {count} selected {file_str}? This cannot be undone."
+                    ),
+                ))
+            }
+            Self::All(count) => {
+                let file_str = if *count == 1 { "file" } else { "files" };
+                Some((
+                    "Discard all changes?".to_string(),
+                    format!(
+                        "Are you sure you want to discard all changes across {count} {file_str}? This cannot be undone."
+                    ),
+                ))
+            }
+        }
+    }
 }
 
 pub fn discard_options(

--- a/crates/threadlane-gpui/src/screens/right_panel/types.rs
+++ b/crates/threadlane-gpui/src/screens/right_panel/types.rs
@@ -156,8 +156,58 @@ pub enum GitAction {
     PopStash(Option<usize>),
     DropStash(Option<usize>),
     DiscardFile(String),
+    DiscardFiles(Vec<String>),
+    DiscardAll,
     IgnoreFile(String),
     IgnoreExtension(String),
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum DiscardOption {
+    Single(String),
+    Selected(Vec<String>),
+    All(usize),
+}
+
+impl DiscardOption {
+    pub fn label(&self) -> String {
+        match self {
+            Self::Single(_) => "Discard Changes...".to_string(),
+            Self::Selected(paths) => format!("Discard Selected Changes ({})...", paths.len()),
+            Self::All(count) => format!("Discard All Changes ({count})..."),
+        }
+    }
+}
+
+pub fn discard_options(
+    clicked_path: &str,
+    selected_paths: &[String],
+    total_files: usize,
+) -> Vec<DiscardOption> {
+    let mut options = vec![DiscardOption::Single(clicked_path.to_string())];
+    let selected_count = selected_paths.len();
+    if selected_count > 1 && selected_count < total_files {
+        options.push(DiscardOption::Selected(selected_paths.to_vec()));
+    }
+    if total_files > 1 {
+        options.push(DiscardOption::All(total_files));
+    }
+    options
+}
+
+pub fn selection_bar_discard_options(
+    selected_paths: &[String],
+    total_files: usize,
+) -> Vec<DiscardOption> {
+    let mut options = Vec::new();
+    let selected_count = selected_paths.len();
+    if selected_count > 0 && selected_count < total_files {
+        options.push(DiscardOption::Selected(selected_paths.to_vec()));
+    }
+    if total_files > 0 {
+        options.push(DiscardOption::All(total_files));
+    }
+    options
 }
 
 #[derive(Clone, Debug)]

--- a/crates/threadlane-gpui/src/screens/right_panel/view.rs
+++ b/crates/threadlane-gpui/src/screens/right_panel/view.rs
@@ -26,9 +26,10 @@ use crate::state::AppState;
 use super::browser::BrowserView;
 use super::draft_pr::{draft_pr_prefill, DraftPrContextKey, DraftPrDialogView};
 pub(crate) use super::types::{
-    can_create_pull_request, can_publish_branch, detect_language,
-    message_generated_matches_active_project, normalize_generated_commit_message, FileNode,
-    GitAction, PanelEvent, ReviewTab, Surface,
+    can_create_pull_request, can_publish_branch, detect_language, discard_options,
+    message_generated_matches_active_project, normalize_generated_commit_message,
+    selection_bar_discard_options, DiscardOption, FileNode, GitAction, PanelEvent, ReviewTab,
+    Surface,
 };
 
 pub struct RightPanelView {
@@ -901,6 +902,14 @@ impl RightPanelView {
             GitAction::PopStash(_) => "Restoring stashed changes…".to_string(),
             GitAction::DropStash(_) => "Discarding stash…".to_string(),
             GitAction::DiscardFile(p) => format!("Discarding changes in {p}…"),
+            GitAction::DiscardFiles(paths) => {
+                if paths.len() == 1 {
+                    format!("Discarding changes in {}…", paths[0])
+                } else {
+                    format!("Discarding changes in {} files…", paths.len())
+                }
+            }
+            GitAction::DiscardAll => "Discarding all changes…".to_string(),
             GitAction::IgnoreFile(p) => format!("Adding {p} to .gitignore…"),
             GitAction::IgnoreExtension(ext) => format!("Ignoring *.{ext} files…"),
         };
@@ -978,6 +987,23 @@ impl RightPanelView {
                     GitAction::DiscardFile(path) => {
                         threadlane_git::discard_file_changes(&work_dir, path)
                             .map_err(|e| e.to_string())?;
+                        action_message = Some(format!("Discarded changes in {path}"));
+                    }
+                    GitAction::DiscardFiles(paths) => {
+                        if !paths.is_empty() {
+                            threadlane_git::discard_files(&work_dir, paths)
+                                .map_err(|e| e.to_string())?;
+                            action_message = Some(if paths.len() == 1 {
+                                format!("Discarded changes in {}", paths[0])
+                            } else {
+                                format!("Discarded changes in {} files", paths.len())
+                            });
+                        }
+                    }
+                    GitAction::DiscardAll => {
+                        threadlane_git::discard_all_changes(&work_dir)
+                            .map_err(|e| e.to_string())?;
+                        action_message = Some("Discarded all changes".to_string());
                     }
                     GitAction::IgnoreFile(path) => {
                         threadlane_git::ignore_file(&work_dir, path).map_err(|e| e.to_string())?;
@@ -1673,29 +1699,43 @@ impl RightPanelView {
                     let rel_path_2 = path.clone();
                     let project_ref = project.clone();
                     let model_ref = model.clone();
-                    let panel_discard = panel.clone();
                     let panel_ignore = panel.clone();
                     let panel_ignore_ext = panel.clone();
 
-                    let mut menu = menu
-                        .item(PopupMenuItem::new("Discard Changes...").on_click(
+                    let mut menu = menu;
+                    let (selected_paths, total_files) = {
+                        let panel_ref = panel.read(_cx);
+                        let selected_paths: Vec<String> =
+                            panel_ref.selected_files.iter().cloned().collect();
+                        (selected_paths, panel_ref.review_files.len())
+                    };
+                    for opt in discard_options(&discard_path, &selected_paths, total_files) {
+                        let panel_action = panel.clone();
+                        let label = opt.label();
+                        let action = match opt {
+                            DiscardOption::Single(p) => GitAction::DiscardFile(p),
+                            DiscardOption::Selected(paths) => GitAction::DiscardFiles(paths),
+                            DiscardOption::All(_) => GitAction::DiscardAll,
+                        };
+                        menu = menu.item(PopupMenuItem::new(label).on_click(
                             move |_event, window, cx| {
-                                let p = discard_path.clone();
-                                panel_discard.update(cx, |this, cx| {
-                                    this.run_git_action(GitAction::DiscardFile(p), window, cx);
+                                let act = action.clone();
+                                panel_action.update(cx, |this, cx| {
+                                    this.run_git_action(act, window, cx);
                                 });
                             },
-                        ))
-                        .item(
-                            PopupMenuItem::new("Ignore File (Add to .gitignore)").on_click(
-                                move |_event, window, cx| {
-                                    let p = ignore_path.clone();
-                                    panel_ignore.update(cx, |this, cx| {
-                                        this.run_git_action(GitAction::IgnoreFile(p), window, cx);
-                                    });
-                                },
-                            ),
-                        );
+                        ));
+                    }
+                    menu = menu.item(
+                        PopupMenuItem::new("Ignore File (Add to .gitignore)").on_click(
+                            move |_event, window, cx| {
+                                let p = ignore_path.clone();
+                                panel_ignore.update(cx, |this, cx| {
+                                    this.run_git_action(GitAction::IgnoreFile(p), window, cx);
+                                });
+                            },
+                        ),
+                    );
 
                     if let Some(ext_str) = ext.clone() {
                         let ext_action = ext_str.clone();
@@ -1806,6 +1846,7 @@ impl RightPanelView {
             self.review_files_list_state
                 .reset_with_uniform_height(self.review_files.len(), px(32.0));
         }
+        let panel_entity = cx.entity().clone();
         let theme = cx.theme().colors;
         if let Some(error) = &self.review_error {
             return self.render_empty("Review unavailable", error, cx);
@@ -2221,6 +2262,7 @@ impl RightPanelView {
         let has_staged = staged_count > 0;
 
         let selection_bar = (total_files > 0).then(|| {
+            let panel_sb = panel_entity.clone();
             div()
                 .flex()
                 .items_center()
@@ -2230,6 +2272,69 @@ impl RightPanelView {
                 .border_b_1()
                 .border_color(theme.border)
                 .bg(theme.muted.opacity(0.15))
+                .context_menu({
+                    let panel = panel_sb;
+                    move |menu, _window, cx| {
+                        let (selected_paths, total_files, unstaged_count, has_staged) = {
+                            let panel_ref = panel.read(cx);
+                            let selected_paths: Vec<String> =
+                                panel_ref.selected_files.iter().cloned().collect();
+                            let total = panel_ref.review_files.len();
+                            let unstaged =
+                                panel_ref.review_files.iter().filter(|f| f.unstaged).count();
+                            let staged =
+                                panel_ref.review_files.iter().any(|f| f.staged);
+                            (selected_paths, total, unstaged, staged)
+                        };
+                        let mut menu = menu;
+                        for opt in selection_bar_discard_options(&selected_paths, total_files) {
+                            let panel_action = panel.clone();
+                            let label = opt.label();
+                            let action = match opt {
+                                DiscardOption::Single(p) => GitAction::DiscardFile(p),
+                                DiscardOption::Selected(paths) => GitAction::DiscardFiles(paths),
+                                DiscardOption::All(_) => GitAction::DiscardAll,
+                            };
+                            menu = menu.item(PopupMenuItem::new(label).on_click(
+                                move |_event, window, cx| {
+                                    let act = action.clone();
+                                    panel_action.update(cx, |this, cx| {
+                                        this.run_git_action(act, window, cx);
+                                    });
+                                },
+                            ));
+                        }
+                        if total_files > 0 {
+                            let panel_stage = panel.clone();
+                            menu = menu.separator().item(
+                                PopupMenuItem::new("Stage All")
+                                    .disabled(unstaged_count == 0)
+                                    .on_click(move |_event, window, cx| {
+                                        panel_stage.update(cx, |this, cx| {
+                                            this.run_git_action(GitAction::StageAll, window, cx);
+                                        });
+                                    }),
+                            );
+                            if has_staged {
+                                let panel_unstage = panel.clone();
+                                menu = menu.item(
+                                    PopupMenuItem::new("Unstage All").on_click(
+                                        move |_event, window, cx| {
+                                            panel_unstage.update(cx, |this, cx| {
+                                                this.run_git_action(
+                                                    GitAction::UnstageAll,
+                                                    window,
+                                                    cx,
+                                                );
+                                            });
+                                        },
+                                    ),
+                                );
+                            }
+                        }
+                        menu
+                    }
+                })
                 .child(
                     div()
                         .flex()
@@ -2333,10 +2438,41 @@ impl RightPanelView {
                 )
                 .into_any_element()
         } else {
+            let panel_fl = panel_entity.clone();
             div()
                 .relative()
                 .flex_1()
                 .min_h_0()
+                .context_menu({
+                    let panel = panel_fl;
+                    move |menu, _window, cx| {
+                        let (selected_paths, total_files) = {
+                            let panel_ref = panel.read(cx);
+                            let selected_paths: Vec<String> =
+                                panel_ref.selected_files.iter().cloned().collect();
+                            (selected_paths, panel_ref.review_files.len())
+                        };
+                        let mut menu = menu;
+                        for opt in selection_bar_discard_options(&selected_paths, total_files) {
+                            let panel_action = panel.clone();
+                            let label = opt.label();
+                            let action = match opt {
+                                DiscardOption::Single(p) => GitAction::DiscardFile(p),
+                                DiscardOption::Selected(paths) => GitAction::DiscardFiles(paths),
+                                DiscardOption::All(_) => GitAction::DiscardAll,
+                            };
+                            menu = menu.item(PopupMenuItem::new(label).on_click(
+                                move |_event, window, cx| {
+                                    let act = action.clone();
+                                    panel_action.update(cx, |this, cx| {
+                                        this.run_git_action(act, window, cx);
+                                    });
+                                },
+                            ));
+                        }
+                        menu
+                    }
+                })
                 .child(
                     list(
                         self.review_files_list_state.clone(),

--- a/crates/threadlane-gpui/src/screens/right_panel/view.rs
+++ b/crates/threadlane-gpui/src/screens/right_panel/view.rs
@@ -705,15 +705,7 @@ impl RightPanelView {
                         self.last_fetched_time = Some(std::time::Instant::now());
                         let action_failed = action_error.is_some();
                         let message = action_error
-                            .or_else(|| {
-                                action_message.map(|message| {
-                                    if message.is_empty() {
-                                        "Pull request created successfully.".into()
-                                    } else {
-                                        format!("Pull request created: {message}")
-                                    }
-                                })
-                            })
+                            .or(action_message)
                             .unwrap_or_else(|| "Git action completed successfully.".into());
                         self.git_feedback = Some(message.clone());
                         self.pending_git_notifications.push(if action_failed {
@@ -846,12 +838,31 @@ impl RightPanelView {
         window: &mut Window,
         cx: &mut Context<Self>,
     ) {
+        self.execute_git_action(action, Some(window), cx);
+    }
+
+    pub(crate) fn run_git_action_without_window(
+        &mut self,
+        action: GitAction,
+        cx: &mut Context<Self>,
+    ) {
+        self.execute_git_action(action, None, cx);
+    }
+
+    fn execute_git_action(
+        &mut self,
+        action: GitAction,
+        mut window: Option<&mut Window>,
+        cx: &mut Context<Self>,
+    ) {
         let Some(work_dir) = self.project.clone() else {
             self.git_feedback = Some("Attach a project to use Git actions.".into());
-            window.push_notification(
-                Notification::warning("Attach a project to use Git actions"),
-                cx,
-            );
+            let notif = Notification::warning("Attach a project to use Git actions");
+            if let Some(ref mut window) = window {
+                window.push_notification(notif, cx);
+            } else {
+                self.pending_git_notifications.push(notif);
+            }
             cx.notify();
             return;
         };
@@ -869,16 +880,23 @@ impl RightPanelView {
         if matches!(action, GitAction::Commit | GitAction::CommitAndPush) {
             if selected_paths.is_empty() {
                 self.git_feedback = Some("Select at least one file to commit.".into());
-                window.push_notification(
-                    Notification::warning("Select at least one file to commit"),
-                    cx,
-                );
+                let notif = Notification::warning("Select at least one file to commit");
+                if let Some(ref mut window) = window {
+                    window.push_notification(notif, cx);
+                } else {
+                    self.pending_git_notifications.push(notif);
+                }
                 cx.notify();
                 return;
             }
             if message.is_empty() {
                 self.git_feedback = Some("Enter a commit message first.".into());
-                window.push_notification(Notification::warning("Enter a commit message first"), cx);
+                let notif = Notification::warning("Enter a commit message first");
+                if let Some(ref mut window) = window {
+                    window.push_notification(notif, cx);
+                } else {
+                    self.pending_git_notifications.push(notif);
+                }
                 cx.notify();
                 return;
             }
@@ -914,7 +932,12 @@ impl RightPanelView {
             GitAction::IgnoreExtension(ext) => format!("Ignoring *.{ext} files…"),
         };
         self.git_feedback = Some(feedback.clone());
-        window.push_notification(Notification::info(feedback), cx);
+        let notif = Notification::info(feedback);
+        if let Some(ref mut window) = window {
+            window.push_notification(notif, cx);
+        } else {
+            self.pending_git_notifications.push(notif);
+        }
         let tx = self.event_tx.clone();
         std::thread::spawn(move || {
             let action_result = (|| {
@@ -955,10 +978,13 @@ impl RightPanelView {
                         threadlane_git::unstage_all(&work_dir).map_err(|e| e.to_string())?;
                     }
                     GitAction::CreatePullRequest => {
-                        action_message = Some(
-                            threadlane_git::create_pull_request(&work_dir)
-                                .map_err(|e| e.to_string())?,
-                        );
+                        let pr = threadlane_git::create_pull_request(&work_dir)
+                            .map_err(|e| e.to_string())?;
+                        action_message = Some(if pr.is_empty() {
+                            "Pull request created successfully.".into()
+                        } else {
+                            format!("Pull request created: {pr}")
+                        });
                     }
                     GitAction::Checkout(branch) => {
                         threadlane_git::checkout(&work_dir, branch).map_err(|e| e.to_string())?;
@@ -1541,6 +1567,40 @@ impl RightPanelView {
             .into_any_element()
     }
 
+    pub(crate) fn handle_discard_option(
+        panel: Entity<RightPanelView>,
+        opt: DiscardOption,
+        window: &mut Window,
+        cx: &mut App,
+    ) {
+        if opt.requires_confirmation() {
+            let (title, description) = opt.confirmation_prompt().unwrap_or((
+                "Discard changes?".into(),
+                "Are you sure you want to discard these changes? This cannot be undone.".into(),
+            ));
+            let action = opt.git_action();
+            cx.spawn(async move |cx| {
+                let confirmed = rfd::AsyncMessageDialog::new()
+                    .set_title(&title)
+                    .set_description(&description)
+                    .set_buttons(rfd::MessageButtons::YesNo)
+                    .show()
+                    .await;
+                if matches!(confirmed, rfd::MessageDialogResult::Yes) {
+                    let _ = panel.update(cx, |this, cx| {
+                        this.run_git_action_without_window(action, cx);
+                    });
+                }
+            })
+            .detach();
+        } else {
+            let action = opt.git_action();
+            panel.update(cx, |this, cx| {
+                this.run_git_action(action, window, cx);
+            });
+        }
+    }
+
     fn render_review_file_row(
         &mut self,
         index: usize,
@@ -1712,17 +1772,15 @@ impl RightPanelView {
                     for opt in discard_options(&discard_path, &selected_paths, total_files) {
                         let panel_action = panel.clone();
                         let label = opt.label();
-                        let action = match opt {
-                            DiscardOption::Single(p) => GitAction::DiscardFile(p),
-                            DiscardOption::Selected(paths) => GitAction::DiscardFiles(paths),
-                            DiscardOption::All(_) => GitAction::DiscardAll,
-                        };
+                        let opt_action = opt.clone();
                         menu = menu.item(PopupMenuItem::new(label).on_click(
                             move |_event, window, cx| {
-                                let act = action.clone();
-                                panel_action.update(cx, |this, cx| {
-                                    this.run_git_action(act, window, cx);
-                                });
+                                Self::handle_discard_option(
+                                    panel_action.clone(),
+                                    opt_action.clone(),
+                                    window,
+                                    cx,
+                                );
                             },
                         ));
                     }
@@ -2290,17 +2348,15 @@ impl RightPanelView {
                         for opt in selection_bar_discard_options(&selected_paths, total_files) {
                             let panel_action = panel.clone();
                             let label = opt.label();
-                            let action = match opt {
-                                DiscardOption::Single(p) => GitAction::DiscardFile(p),
-                                DiscardOption::Selected(paths) => GitAction::DiscardFiles(paths),
-                                DiscardOption::All(_) => GitAction::DiscardAll,
-                            };
+                            let opt_action = opt.clone();
                             menu = menu.item(PopupMenuItem::new(label).on_click(
                                 move |_event, window, cx| {
-                                    let act = action.clone();
-                                    panel_action.update(cx, |this, cx| {
-                                        this.run_git_action(act, window, cx);
-                                    });
+                                    Self::handle_discard_option(
+                                        panel_action.clone(),
+                                        opt_action.clone(),
+                                        window,
+                                        cx,
+                                    );
                                 },
                             ));
                         }
@@ -2456,17 +2512,15 @@ impl RightPanelView {
                         for opt in selection_bar_discard_options(&selected_paths, total_files) {
                             let panel_action = panel.clone();
                             let label = opt.label();
-                            let action = match opt {
-                                DiscardOption::Single(p) => GitAction::DiscardFile(p),
-                                DiscardOption::Selected(paths) => GitAction::DiscardFiles(paths),
-                                DiscardOption::All(_) => GitAction::DiscardAll,
-                            };
+                            let opt_action = opt.clone();
                             menu = menu.item(PopupMenuItem::new(label).on_click(
                                 move |_event, window, cx| {
-                                    let act = action.clone();
-                                    panel_action.update(cx, |this, cx| {
-                                        this.run_git_action(act, window, cx);
-                                    });
+                                    Self::handle_discard_option(
+                                        panel_action.clone(),
+                                        opt_action.clone(),
+                                        window,
+                                        cx,
+                                    );
                                 },
                             ));
                         }


### PR DESCRIPTION
## Summary
- Add validated helpers to discard selected files or all working-tree changes.
- Add Git review context-menu actions for single, selected, and bulk discard operations.
- Add selection-bar stage/unstage actions and comprehensive option/lifecycle tests.

## Testing
- Not run (no test execution results provided).