### PR TITLE
Add optional worktree deletion to session archive/remove actions

### DIFF
--- a/crates/threadlane-gpui/src/app/actions.rs
+++ b/crates/threadlane-gpui/src/app/actions.rs
@@ -13,10 +13,12 @@ pub enum AppAction {
     SettleSession {
         work_dir: PathBuf,
         session_id: String,
+        delete_worktree: bool,
     },
     RemoveSession {
         work_dir: PathBuf,
         session_id: String,
+        delete_worktree: bool,
     },
     ToggleProject(PathBuf),
     SetSidebarProjectFilter(Option<PathBuf>),

--- a/crates/threadlane-gpui/src/app/controller.rs
+++ b/crates/threadlane-gpui/src/app/controller.rs
@@ -19,16 +19,18 @@ pub(crate) fn dispatch(state: &mut AppState, action: AppAction) -> Option<Sessio
         AppAction::SettleSession {
             work_dir,
             session_id,
+            delete_worktree,
         } => {
-            if let Err(error) = state.settle_session(work_dir, session_id) {
+            if let Err(error) = state.settle_session(work_dir, session_id, delete_worktree) {
                 state.session_status = Some(error);
             }
         }
         AppAction::RemoveSession {
             work_dir,
             session_id,
+            delete_worktree,
         } => {
-            if let Err(error) = state.remove_session(work_dir, session_id) {
+            if let Err(error) = state.remove_session(work_dir, session_id, delete_worktree) {
                 state.session_status = Some(error);
             }
         }

--- a/crates/threadlane-gpui/src/screens/sidebar/view.rs
+++ b/crates/threadlane-gpui/src/screens/sidebar/view.rs
@@ -1,8 +1,13 @@
+use std::cell::Cell;
+use std::path::PathBuf;
+use std::rc::Rc;
+
 use gpui::prelude::FluentBuilder;
 use gpui::InteractiveElement;
 use gpui::*;
 
 use gpui_component::button::{Button, ButtonVariant, ButtonVariants};
+use gpui_component::checkbox::Checkbox;
 use gpui_component::dialog::DialogButtonProps;
 use gpui_component::input::{Input, InputEvent, InputState};
 use gpui_component::menu::{ContextMenuExt, DropdownMenu, PopupMenuItem};
@@ -13,6 +18,167 @@ use gpui_component::{Icon, IconName, Selectable, Sizable, WindowExt};
 
 use crate::app::{actions::AppAction, controller};
 use crate::state::{AppState, SessionAttention, SessionInfo, TrajectoryEntry};
+
+fn open_archive_session_dialog(
+    window: &mut Window,
+    cx: &mut App,
+    model: Entity<AppState>,
+    work_dir: PathBuf,
+    session_id: String,
+    is_worktree: bool,
+    git_branch: Option<String>,
+) {
+    let delete_worktree = Rc::new(Cell::new(true));
+    window.open_alert_dialog(cx, {
+        let model = model.clone();
+        let work_dir = work_dir.clone();
+        let session_id = session_id.clone();
+        let delete_worktree = delete_worktree.clone();
+        move |alert, _window, cx| {
+            let model = model.clone();
+            let work_dir = work_dir.clone();
+            let session_id = session_id.clone();
+            let delete_worktree = delete_worktree.clone();
+            let mut alert = alert
+                .title("Archive session?")
+                .description(format!(
+                    "This removes session {session_id} from the active list."
+                ))
+                .button_props(
+                    DialogButtonProps::default()
+                        .ok_text("Archive")
+                        .show_cancel(true),
+                );
+
+            if is_worktree {
+                let delete_worktree_click = delete_worktree.clone();
+                let model_click = model.clone();
+                let label = if let Some(branch) = &git_branch {
+                    format!("Delete associated worktree ({branch})")
+                } else {
+                    "Delete associated worktree".to_string()
+                };
+                alert = alert.child(
+                    div().pt_2().child(
+                        Checkbox::new(SharedString::from(format!(
+                            "archive-delete-worktree-{}",
+                            session_id
+                        )))
+                        .checked(delete_worktree.get())
+                        .label(label)
+                        .on_click(move |checked, _window, cx| {
+                            delete_worktree_click.set(*checked);
+                            model_click.update(cx, |_state, cx| {
+                                cx.notify();
+                            });
+                        }),
+                    ),
+                );
+            }
+
+            alert.on_ok(move |_event, _window, cx| {
+                let delete_worktree_val = if is_worktree {
+                    delete_worktree.get()
+                } else {
+                    false
+                };
+                model.update(cx, |state, cx| {
+                    controller::dispatch(
+                        state,
+                        AppAction::SettleSession {
+                            work_dir: work_dir.clone(),
+                            session_id: session_id.clone(),
+                            delete_worktree: delete_worktree_val,
+                        },
+                    );
+                    cx.notify();
+                });
+                true
+            })
+        }
+    });
+}
+
+fn open_remove_session_dialog(
+    window: &mut Window,
+    cx: &mut App,
+    model: Entity<AppState>,
+    work_dir: PathBuf,
+    session_id: String,
+    is_worktree: bool,
+    git_branch: Option<String>,
+) {
+    let delete_worktree = Rc::new(Cell::new(true));
+    window.open_alert_dialog(cx, {
+        let model = model.clone();
+        let work_dir = work_dir.clone();
+        let session_id = session_id.clone();
+        let delete_worktree = delete_worktree.clone();
+        move |alert, _window, cx| {
+            let model = model.clone();
+            let work_dir = work_dir.clone();
+            let session_id = session_id.clone();
+            let delete_worktree = delete_worktree.clone();
+            let mut alert = alert
+                .title("Remove session?")
+                .description(format!(
+                    "This permanently removes session {session_id}."
+                ))
+                .button_props(
+                    DialogButtonProps::default()
+                        .ok_text("Remove")
+                        .ok_variant(ButtonVariant::Danger)
+                        .show_cancel(true),
+                );
+
+            if is_worktree {
+                let delete_worktree_click = delete_worktree.clone();
+                let model_click = model.clone();
+                let label = if let Some(branch) = &git_branch {
+                    format!("Delete associated worktree ({branch})")
+                } else {
+                    "Delete associated worktree".to_string()
+                };
+                alert = alert.child(
+                    div().pt_2().child(
+                        Checkbox::new(SharedString::from(format!(
+                            "remove-delete-worktree-{}",
+                            session_id
+                        )))
+                        .checked(delete_worktree.get())
+                        .label(label)
+                        .on_click(move |checked, _window, cx| {
+                            delete_worktree_click.set(*checked);
+                            model_click.update(cx, |_state, cx| {
+                                cx.notify();
+                            });
+                        }),
+                    ),
+                );
+            }
+
+            alert.on_ok(move |_event, _window, cx| {
+                let delete_worktree_val = if is_worktree {
+                    delete_worktree.get()
+                } else {
+                    false
+                };
+                model.update(cx, |state, cx| {
+                    controller::dispatch(
+                        state,
+                        AppAction::RemoveSession {
+                            work_dir: work_dir.clone(),
+                            session_id: session_id.clone(),
+                            delete_worktree: delete_worktree_val,
+                        },
+                    );
+                    cx.notify();
+                });
+                true
+            })
+        }
+    });
+}
 
 fn safe_file_stem(title: &str) -> String {
     let stem = title
@@ -786,6 +952,8 @@ impl SidebarView {
         let quick_settle_model = self.model.clone();
         let quick_settle_work_dir = session.work_dir.clone();
         let quick_settle_session_id = session.id.clone();
+        let quick_settle_is_worktree = session.is_worktree;
+        let quick_settle_git_branch = session.git_branch.clone();
         let time_ago = format_time_ago(session.updated_at, now_unix_secs());
         let project = self
             .model
@@ -1147,18 +1315,31 @@ impl SidebarView {
                                             cx.stop_propagation();
                                         })
                                         .on_click(
-                                            move |_event, _window, cx| {
-                                                quick_settle_model.update(cx, |state, cx| {
-                                                    controller::dispatch(
-                                                        state,
-                                                        AppAction::SettleSession {
-                                                            work_dir: quick_settle_work_dir.clone(),
-                                                            session_id: quick_settle_session_id
-                                                                .clone(),
-                                                        },
+                                            move |_event, window, cx| {
+                                                if quick_settle_is_worktree {
+                                                    open_archive_session_dialog(
+                                                        window,
+                                                        cx,
+                                                        quick_settle_model.clone(),
+                                                        quick_settle_work_dir.clone(),
+                                                        quick_settle_session_id.clone(),
+                                                        true,
+                                                        quick_settle_git_branch.clone(),
                                                     );
-                                                    cx.notify();
-                                                });
+                                                } else {
+                                                    quick_settle_model.update(cx, |state, cx| {
+                                                        controller::dispatch(
+                                                            state,
+                                                            AppAction::SettleSession {
+                                                                work_dir: quick_settle_work_dir.clone(),
+                                                                session_id: quick_settle_session_id
+                                                                    .clone(),
+                                                                delete_worktree: false,
+                                                            },
+                                                        );
+                                                        cx.notify();
+                                                    });
+                                                }
                                             },
                                         ),
                                     ),
@@ -1195,9 +1376,13 @@ impl SidebarView {
                 let settle_model = context_model.clone();
                 let settle_work_dir = context_work_dir.clone();
                 let settle_session_id = context_session_id.clone();
+                let settle_is_worktree = session.is_worktree;
+                let settle_git_branch = session.git_branch.clone();
                 let remove_model = context_model.clone();
                 let remove_work_dir = context_work_dir.clone();
                 let remove_session_id = context_session_id.clone();
+                let remove_is_worktree = session.is_worktree;
+                let remove_git_branch = session.git_branch.clone();
 
                 menu.item(PopupMenuItem::new("Open Session").on_click(
                     move |_event, _window, cx| {
@@ -1338,80 +1523,29 @@ impl SidebarView {
                 .separator()
                 .item(
                     PopupMenuItem::new("Archive Session").on_click(move |_event, window, cx| {
-                        let model = settle_model.clone();
-                        let work_dir = settle_work_dir.clone();
-                        let session_id = settle_session_id.clone();
-                        window.open_alert_dialog(cx, {
-                            let model = model.clone();
-                            let work_dir = work_dir.clone();
-                            let session_id = session_id.clone();
-                            move |alert, _window, _cx| {
-                                let model = model.clone();
-                                let work_dir = work_dir.clone();
-                                let session_id = session_id.clone();
-                                alert
-                                    .title("Archive session?")
-                                    .description(format!(
-                                        "This removes session {session_id} from the active list."
-                                    ))
-                                    .show_cancel(true)
-                                    .on_ok(move |_event, _window, cx| {
-                                        model.update(cx, |state, cx| {
-                                            controller::dispatch(
-                                                state,
-                                                AppAction::SettleSession {
-                                                    work_dir: work_dir.clone(),
-                                                    session_id: session_id.clone(),
-                                                },
-                                            );
-                                            cx.notify();
-                                        });
-                                        true
-                                    })
-                            }
-                        });
+                        open_archive_session_dialog(
+                            window,
+                            cx,
+                            settle_model.clone(),
+                            settle_work_dir.clone(),
+                            settle_session_id.clone(),
+                            settle_is_worktree,
+                            settle_git_branch.clone(),
+                        );
                     }),
                 )
                 .separator()
                 .item(
                     PopupMenuItem::new("Remove Session").on_click(move |_event, window, cx| {
-                        let model = remove_model.clone();
-                        let work_dir = remove_work_dir.clone();
-                        let session_id = remove_session_id.clone();
-                        window.open_alert_dialog(cx, {
-                            let model = model.clone();
-                            let work_dir = work_dir.clone();
-                            let session_id = session_id.clone();
-                            move |alert, _window, _cx| {
-                                let model = model.clone();
-                                let work_dir = work_dir.clone();
-                                let session_id = session_id.clone();
-                                alert
-                                    .title("Remove session?")
-                                    .description(format!(
-                                        "This permanently removes session {session_id}."
-                                    ))
-                                    .button_props(
-                                        DialogButtonProps::default()
-                                            .ok_text("Remove")
-                                            .ok_variant(ButtonVariant::Danger)
-                                            .show_cancel(true),
-                                    )
-                                    .on_ok(move |_event, _window, cx| {
-                                        model.update(cx, |state, cx| {
-                                            controller::dispatch(
-                                                state,
-                                                AppAction::RemoveSession {
-                                                    work_dir: work_dir.clone(),
-                                                    session_id: session_id.clone(),
-                                                },
-                                            );
-                                            cx.notify();
-                                        });
-                                        true
-                                    })
-                            }
-                        });
+                        open_remove_session_dialog(
+                            window,
+                            cx,
+                            remove_model.clone(),
+                            remove_work_dir.clone(),
+                            remove_session_id.clone(),
+                            remove_is_worktree,
+                            remove_git_branch.clone(),
+                        );
                     }),
                 )
             })

--- a/crates/threadlane-gpui/src/screens/sidebar/view.rs
+++ b/crates/threadlane-gpui/src/screens/sidebar/view.rs
@@ -34,7 +34,7 @@ fn open_archive_session_dialog(
         let work_dir = work_dir.clone();
         let session_id = session_id.clone();
         let delete_worktree = delete_worktree.clone();
-        move |alert, _window, cx| {
+        move |alert, _window, _cx| {
             let model = model.clone();
             let work_dir = work_dir.clone();
             let session_id = session_id.clone();
@@ -114,7 +114,7 @@ fn open_remove_session_dialog(
         let work_dir = work_dir.clone();
         let session_id = session_id.clone();
         let delete_worktree = delete_worktree.clone();
-        move |alert, _window, cx| {
+        move |alert, _window, _cx| {
             let model = model.clone();
             let work_dir = work_dir.clone();
             let session_id = session_id.clone();
@@ -946,6 +946,8 @@ impl SidebarView {
         let context_work_dir = session.work_dir.clone();
         let context_session_id = session.id.clone();
         let context_model = self.model.clone();
+        let context_is_worktree = session.is_worktree;
+        let context_git_branch = session.git_branch.clone();
         let copy_session_file = session.session_file.display().to_string();
         let export_log_source = session.session_file.clone();
         let export_trajectory_title = session.title.clone();
@@ -1376,13 +1378,13 @@ impl SidebarView {
                 let settle_model = context_model.clone();
                 let settle_work_dir = context_work_dir.clone();
                 let settle_session_id = context_session_id.clone();
-                let settle_is_worktree = session.is_worktree;
-                let settle_git_branch = session.git_branch.clone();
+                let settle_is_worktree = context_is_worktree;
+                let settle_git_branch = context_git_branch.clone();
                 let remove_model = context_model.clone();
                 let remove_work_dir = context_work_dir.clone();
                 let remove_session_id = context_session_id.clone();
-                let remove_is_worktree = session.is_worktree;
-                let remove_git_branch = session.git_branch.clone();
+                let remove_is_worktree = context_is_worktree;
+                let remove_git_branch = context_git_branch.clone();
 
                 menu.item(PopupMenuItem::new("Open Session").on_click(
                     move |_event, _window, cx| {

--- a/crates/threadlane-gpui/src/screens/sidebar/view.rs
+++ b/crates/threadlane-gpui/src/screens/sidebar/view.rs
@@ -19,7 +19,68 @@ use gpui_component::{Icon, IconName, Selectable, Sizable, WindowExt};
 use crate::app::{actions::AppAction, controller};
 use crate::state::{AppState, SessionAttention, SessionInfo, TrajectoryEntry};
 
-fn open_archive_session_dialog(
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum SessionRemovalKind {
+    Archive,
+    Remove,
+}
+
+impl SessionRemovalKind {
+    fn title(self) -> &'static str {
+        match self {
+            Self::Archive => "Archive session?",
+            Self::Remove => "Remove session?",
+        }
+    }
+
+    fn description(self, session_id: &str) -> String {
+        match self {
+            Self::Archive => format!("This removes session {session_id} from the active list."),
+            Self::Remove => format!("This permanently removes session {session_id}."),
+        }
+    }
+
+    fn action_prefix(self) -> &'static str {
+        match self {
+            Self::Archive => "archive",
+            Self::Remove => "remove",
+        }
+    }
+
+    fn button_props(self) -> DialogButtonProps {
+        match self {
+            Self::Archive => DialogButtonProps::default()
+                .ok_text("Archive")
+                .show_cancel(true),
+            Self::Remove => DialogButtonProps::default()
+                .ok_text("Remove")
+                .ok_variant(ButtonVariant::Danger)
+                .show_cancel(true),
+        }
+    }
+
+    fn dispatch_action(
+        self,
+        work_dir: PathBuf,
+        session_id: String,
+        delete_worktree: bool,
+    ) -> AppAction {
+        match self {
+            Self::Archive => AppAction::SettleSession {
+                work_dir,
+                session_id,
+                delete_worktree,
+            },
+            Self::Remove => AppAction::RemoveSession {
+                work_dir,
+                session_id,
+                delete_worktree,
+            },
+        }
+    }
+}
+
+fn open_session_removal_dialog(
     window: &mut Window,
     cx: &mut App,
     model: Entity<AppState>,
@@ -27,6 +88,7 @@ fn open_archive_session_dialog(
     session_id: String,
     is_worktree: bool,
     git_branch: Option<String>,
+    kind: SessionRemovalKind,
 ) {
     let delete_worktree = Rc::new(Cell::new(true));
     window.open_alert_dialog(cx, {
@@ -40,15 +102,9 @@ fn open_archive_session_dialog(
             let session_id = session_id.clone();
             let delete_worktree = delete_worktree.clone();
             let mut alert = alert
-                .title("Archive session?")
-                .description(format!(
-                    "This removes session {session_id} from the active list."
-                ))
-                .button_props(
-                    DialogButtonProps::default()
-                        .ok_text("Archive")
-                        .show_cancel(true),
-                );
+                .title(kind.title())
+                .description(kind.description(&session_id))
+                .button_props(kind.button_props());
 
             if is_worktree {
                 let delete_worktree_click = delete_worktree.clone();
@@ -61,7 +117,8 @@ fn open_archive_session_dialog(
                 alert = alert.child(
                     div().pt_2().child(
                         Checkbox::new(SharedString::from(format!(
-                            "archive-delete-worktree-{}",
+                            "{}-delete-worktree-{}",
+                            kind.action_prefix(),
                             session_id
                         )))
                         .checked(delete_worktree.get())
@@ -85,11 +142,11 @@ fn open_archive_session_dialog(
                 model.update(cx, |state, cx| {
                     controller::dispatch(
                         state,
-                        AppAction::SettleSession {
-                            work_dir: work_dir.clone(),
-                            session_id: session_id.clone(),
-                            delete_worktree: delete_worktree_val,
-                        },
+                        kind.dispatch_action(
+                            work_dir.clone(),
+                            session_id.clone(),
+                            delete_worktree_val,
+                        ),
                     );
                     cx.notify();
                 });
@@ -97,6 +154,27 @@ fn open_archive_session_dialog(
             })
         }
     });
+}
+
+fn open_archive_session_dialog(
+    window: &mut Window,
+    cx: &mut App,
+    model: Entity<AppState>,
+    work_dir: PathBuf,
+    session_id: String,
+    is_worktree: bool,
+    git_branch: Option<String>,
+) {
+    open_session_removal_dialog(
+        window,
+        cx,
+        model,
+        work_dir,
+        session_id,
+        is_worktree,
+        git_branch,
+        SessionRemovalKind::Archive,
+    );
 }
 
 fn open_remove_session_dialog(
@@ -108,76 +186,16 @@ fn open_remove_session_dialog(
     is_worktree: bool,
     git_branch: Option<String>,
 ) {
-    let delete_worktree = Rc::new(Cell::new(true));
-    window.open_alert_dialog(cx, {
-        let model = model.clone();
-        let work_dir = work_dir.clone();
-        let session_id = session_id.clone();
-        let delete_worktree = delete_worktree.clone();
-        move |alert, _window, _cx| {
-            let model = model.clone();
-            let work_dir = work_dir.clone();
-            let session_id = session_id.clone();
-            let delete_worktree = delete_worktree.clone();
-            let mut alert = alert
-                .title("Remove session?")
-                .description(format!(
-                    "This permanently removes session {session_id}."
-                ))
-                .button_props(
-                    DialogButtonProps::default()
-                        .ok_text("Remove")
-                        .ok_variant(ButtonVariant::Danger)
-                        .show_cancel(true),
-                );
-
-            if is_worktree {
-                let delete_worktree_click = delete_worktree.clone();
-                let model_click = model.clone();
-                let label = if let Some(branch) = &git_branch {
-                    format!("Delete associated worktree ({branch})")
-                } else {
-                    "Delete associated worktree".to_string()
-                };
-                alert = alert.child(
-                    div().pt_2().child(
-                        Checkbox::new(SharedString::from(format!(
-                            "remove-delete-worktree-{}",
-                            session_id
-                        )))
-                        .checked(delete_worktree.get())
-                        .label(label)
-                        .on_click(move |checked, _window, cx| {
-                            delete_worktree_click.set(*checked);
-                            model_click.update(cx, |_state, cx| {
-                                cx.notify();
-                            });
-                        }),
-                    ),
-                );
-            }
-
-            alert.on_ok(move |_event, _window, cx| {
-                let delete_worktree_val = if is_worktree {
-                    delete_worktree.get()
-                } else {
-                    false
-                };
-                model.update(cx, |state, cx| {
-                    controller::dispatch(
-                        state,
-                        AppAction::RemoveSession {
-                            work_dir: work_dir.clone(),
-                            session_id: session_id.clone(),
-                            delete_worktree: delete_worktree_val,
-                        },
-                    );
-                    cx.notify();
-                });
-                true
-            })
-        }
-    });
+    open_session_removal_dialog(
+        window,
+        cx,
+        model,
+        work_dir,
+        session_id,
+        is_worktree,
+        git_branch,
+        SessionRemovalKind::Remove,
+    );
 }
 
 fn safe_file_stem(title: &str) -> String {

--- a/crates/threadlane-gpui/src/state/app_state.rs
+++ b/crates/threadlane-gpui/src/state/app_state.rs
@@ -3,7 +3,7 @@ use std::path::{Path, PathBuf};
 use std::sync::Arc;
 use std::sync::mpsc::{self, Sender};
 use std::time::{SystemTime, UNIX_EPOCH};
-use threadlane_session::harness::JsonlStore;
+use threadlane_session::harness::{JsonlStore, SessionStore};
 use threadlane_session::{
     AcpConfigOption, AgentEvent, AgentMessage, ImageAttachment, ReasoningEffort, SessionPlan,
     SubagentProgressUpdate, TokenUsage,

--- a/crates/threadlane-gpui/src/state/app_state.rs
+++ b/crates/threadlane-gpui/src/state/app_state.rs
@@ -774,6 +774,7 @@ impl AppState {
         &mut self,
         work_dir: PathBuf,
         session_id: String,
+        delete_worktree: bool,
     ) -> Result<(), String> {
         let session_file = self.session_file(&work_dir, &session_id);
         if self
@@ -790,7 +791,7 @@ impl AppState {
             .ok_or_else(|| "Session file has no file name".to_string())?;
         let archive_file = archive_dir.join(file_name);
         if let Some(worktree_dir) = self.session_worktree_path(&work_dir, &session_id) {
-            if worktree_dir.exists() {
+            if delete_worktree && worktree_dir.exists() {
                 if threadlane_git::inspect(&worktree_dir)
                     .map_err(|error| error.to_string())?
                     .has_changes
@@ -803,12 +804,23 @@ impl AppState {
                     let _ = std::fs::remove_file(&archive_file);
                     return Err(error.to_string());
                 }
+                let stub = Self::canonical_session_file(&work_dir, &session_id);
+                Self::remove_file_if_present(&stub)?;
+                let _ = threadlane_git::prune_worktrees(&work_dir);
             } else {
-                std::fs::rename(&session_file, &archive_file).map_err(|error| error.to_string())?;
+                if session_file.exists() {
+                    if std::fs::rename(&session_file, &archive_file).is_err() {
+                        std::fs::copy(&session_file, &archive_file)
+                            .map_err(|error| error.to_string())?;
+                        let _ = std::fs::remove_file(&session_file);
+                    }
+                }
+                let stub = Self::canonical_session_file(&work_dir, &session_id);
+                Self::remove_file_if_present(&stub)?;
+                if delete_worktree {
+                    let _ = threadlane_git::prune_worktrees(&work_dir);
+                }
             }
-            let stub = Self::canonical_session_file(&work_dir, &session_id);
-            Self::remove_file_if_present(&stub)?;
-            let _ = threadlane_git::prune_worktrees(&work_dir);
         } else {
             std::fs::rename(&session_file, archive_file).map_err(|error| error.to_string())?;
         }
@@ -820,6 +832,7 @@ impl AppState {
         &mut self,
         work_dir: PathBuf,
         session_id: String,
+        delete_worktree: bool,
     ) -> Result<(), String> {
         let session_file = self.session_file(&work_dir, &session_id);
         if self
@@ -830,12 +843,16 @@ impl AppState {
             return Err("Stop the running generation before deleting this session".into());
         }
         if let Some(worktree_dir) = self.session_worktree_path(&work_dir, &session_id) {
-            if worktree_dir.exists() {
+            if delete_worktree && worktree_dir.exists() {
                 threadlane_git::remove_worktree(&work_dir, &worktree_dir, true)
                     .map_err(|error| error.to_string())?;
+                let _ = threadlane_git::prune_worktrees(&work_dir);
             }
             Self::remove_file_if_present(&Self::canonical_session_file(&work_dir, &session_id))?;
-            let _ = threadlane_git::prune_worktrees(&work_dir);
+            Self::remove_file_if_present(&session_file)?;
+            if delete_worktree {
+                let _ = threadlane_git::prune_worktrees(&work_dir);
+            }
         } else {
             std::fs::remove_file(session_file).map_err(|error| error.to_string())?;
         }
@@ -984,7 +1001,8 @@ impl AppState {
     }
 
     fn session_worktree_path(&self, work_dir: &Path, session_id: &str) -> Option<PathBuf> {
-        self.projects
+        if let Some(path) = self
+            .projects
             .iter()
             .find(|project| project.work_dir == work_dir)
             .and_then(|project| {
@@ -994,6 +1012,23 @@ impl AppState {
                     .find(|session| session.id == session_id && session.is_worktree)
             })
             .map(|session| session.runtime_work_dir.clone())
+        {
+            return Some(path);
+        }
+        let stub = Self::canonical_session_file(work_dir, session_id);
+        let store = JsonlStore::open_read_only(&stub).ok()?;
+        let facts = store.facts();
+        if facts.get("is_worktree").is_some_and(|value| value == "true") {
+            let canonical_work_dir =
+                std::fs::canonicalize(work_dir).unwrap_or_else(|_| work_dir.to_path_buf());
+            Some(crate::state::effective_session_work_dir(
+                &canonical_work_dir,
+                session_id,
+                &facts,
+            ))
+        } else {
+            None
+        }
     }
 
     fn remove_file_if_present(path: &Path) -> Result<(), String> {

--- a/crates/threadlane-gpui/src/state/mod.rs
+++ b/crates/threadlane-gpui/src/state/mod.rs
@@ -4,7 +4,7 @@ mod projection;
 mod types;
 
 pub(crate) use app_state::AppState;
-pub(crate) use discovery::discover_sessions_in_project;
+pub(crate) use discovery::{discover_sessions_in_project, effective_session_work_dir};
 pub(crate) use projection::{
     coding_agent_options, compute_full_session_projection, compute_session_messages,
     provider_credentials, runtime_status_text,

--- a/crates/threadlane-gpui/src/state/tests.rs
+++ b/crates/threadlane-gpui/src/state/tests.rs
@@ -771,7 +771,7 @@ fn removing_worktree_session_removes_checkout_and_metadata_stub() {
     });
 
     state
-        .remove_session(project.clone(), session_id.into())
+        .remove_session(project.clone(), session_id.into(), true)
         .unwrap();
 
     assert!(!worktree.exists());
@@ -781,6 +781,167 @@ fn removing_worktree_session_removes_checkout_and_metadata_stub() {
             .unwrap()
             .iter()
             .all(|entry| entry.branch.as_deref() != Some("worktree/session"))
+    );
+}
+
+#[test]
+fn removing_worktree_session_retains_checkout_when_requested() {
+    let dir = tempfile::tempdir().unwrap();
+    let project = dir.path().canonicalize().unwrap();
+    run_git(&project, &["init", "-b", "main"]);
+    run_git(&project, &["config", "user.email", "test@example.com"]);
+    run_git(&project, &["config", "user.name", "Test"]);
+    std::fs::write(project.join("base.txt"), "base\n").unwrap();
+    run_git(&project, &["add", "."]);
+    run_git(&project, &["commit", "-qm", "initial"]);
+
+    let session_id = "worktree-session";
+    let worktree = project.join(".threadlane/worktrees").join(session_id);
+    threadlane_git::create_worktree(&project, &worktree, "worktree/session").unwrap();
+    let stub = project
+        .join(".threadlane/sessions")
+        .join(format!("{session_id}.jsonl"));
+    let transcript = worktree
+        .join(".threadlane/sessions")
+        .join(format!("{session_id}.jsonl"));
+    std::fs::create_dir_all(stub.parent().unwrap()).unwrap();
+    std::fs::create_dir_all(transcript.parent().unwrap()).unwrap();
+    std::fs::write(&stub, "{}\n").unwrap();
+    std::fs::write(&transcript, "{}\n").unwrap();
+
+    let mut session = test_session(session_id, &transcript);
+    session.work_dir = project.clone();
+    session.runtime_work_dir = worktree.clone();
+    session.is_worktree = true;
+    let mut state = AppState::load_from_registry(Vec::new());
+    state.projects.push(ProjectInfo {
+        name: "project".into(),
+        work_dir: project.clone(),
+        sessions: vec![session],
+        is_expanded: true,
+    });
+
+    state
+        .remove_session(project.clone(), session_id.into(), false)
+        .unwrap();
+
+    assert!(worktree.exists());
+    assert!(!stub.exists());
+    assert!(
+        threadlane_git::list_worktrees(&project)
+            .unwrap()
+            .iter()
+            .any(|entry| entry.branch.as_deref() == Some("worktree/session"))
+    );
+}
+
+#[test]
+fn settling_worktree_session_removes_checkout_when_requested() {
+    let dir = tempfile::tempdir().unwrap();
+    let project = dir.path().canonicalize().unwrap();
+    run_git(&project, &["init", "-b", "main"]);
+    run_git(&project, &["config", "user.email", "test@example.com"]);
+    run_git(&project, &["config", "user.name", "Test"]);
+    std::fs::write(project.join("base.txt"), "base\n").unwrap();
+    run_git(&project, &["add", "."]);
+    run_git(&project, &["commit", "-qm", "initial"]);
+
+    let session_id = "worktree-session";
+    let worktree = project.join(".threadlane/worktrees").join(session_id);
+    threadlane_git::create_worktree(&project, &worktree, "worktree/session").unwrap();
+    let stub = project
+        .join(".threadlane/sessions")
+        .join(format!("{session_id}.jsonl"));
+    let transcript = worktree
+        .join(".threadlane/sessions")
+        .join(format!("{session_id}.jsonl"));
+    std::fs::create_dir_all(stub.parent().unwrap()).unwrap();
+    std::fs::create_dir_all(transcript.parent().unwrap()).unwrap();
+    std::fs::write(&stub, "{}\n").unwrap();
+    std::fs::write(&transcript, "{}\n").unwrap();
+
+    let mut session = test_session(session_id, &transcript);
+    session.work_dir = project.clone();
+    session.runtime_work_dir = worktree.clone();
+    session.is_worktree = true;
+    let mut state = AppState::load_from_registry(Vec::new());
+    state.projects.push(ProjectInfo {
+        name: "project".into(),
+        work_dir: project.clone(),
+        sessions: vec![session],
+        is_expanded: true,
+    });
+
+    state
+        .settle_session(project.clone(), session_id.into(), true)
+        .unwrap();
+
+    let archive_file = project
+        .join(".threadlane/sessions/archive")
+        .join(format!("{session_id}.jsonl"));
+    assert!(archive_file.exists());
+    assert!(!worktree.exists());
+    assert!(!stub.exists());
+    assert!(
+        threadlane_git::list_worktrees(&project)
+            .unwrap()
+            .iter()
+            .all(|entry| entry.branch.as_deref() != Some("worktree/session"))
+    );
+}
+
+#[test]
+fn settling_worktree_session_retains_checkout_when_requested() {
+    let dir = tempfile::tempdir().unwrap();
+    let project = dir.path().canonicalize().unwrap();
+    run_git(&project, &["init", "-b", "main"]);
+    run_git(&project, &["config", "user.email", "test@example.com"]);
+    run_git(&project, &["config", "user.name", "Test"]);
+    std::fs::write(project.join("base.txt"), "base\n").unwrap();
+    run_git(&project, &["add", "."]);
+    run_git(&project, &["commit", "-qm", "initial"]);
+
+    let session_id = "worktree-session";
+    let worktree = project.join(".threadlane/worktrees").join(session_id);
+    threadlane_git::create_worktree(&project, &worktree, "worktree/session").unwrap();
+    let stub = project
+        .join(".threadlane/sessions")
+        .join(format!("{session_id}.jsonl"));
+    let transcript = worktree
+        .join(".threadlane/sessions")
+        .join(format!("{session_id}.jsonl"));
+    std::fs::create_dir_all(stub.parent().unwrap()).unwrap();
+    std::fs::create_dir_all(transcript.parent().unwrap()).unwrap();
+    std::fs::write(&stub, "{}\n").unwrap();
+    std::fs::write(&transcript, "{}\n").unwrap();
+
+    let mut session = test_session(session_id, &transcript);
+    session.work_dir = project.clone();
+    session.runtime_work_dir = worktree.clone();
+    session.is_worktree = true;
+    let mut state = AppState::load_from_registry(Vec::new());
+    state.projects.push(ProjectInfo {
+        name: "project".into(),
+        work_dir: project.clone(),
+        sessions: vec![session],
+        is_expanded: true,
+    });
+
+    state
+        .settle_session(project.clone(), session_id.into(), false)
+        .unwrap();
+
+    let archive_file = project
+        .join(".threadlane/sessions/archive")
+        .join(format!("{session_id}.jsonl"));
+    assert!(archive_file.exists());
+    assert!(worktree.exists());
+    assert!(!stub.exists());
+    assert!(
+        threadlane_git::list_worktrees(&project)
+            .unwrap()
+            .iter()
+            .any(|entry| entry.branch.as_deref() == Some("worktree/session"))
     );
 }
 


### PR DESCRIPTION
## Summary
- Add worktree deletion controls to archive and remove session dialogs.
- Preserve associated worktrees when deletion is disabled.
- Improve session/worktree metadata cleanup and add coverage for both behaviors.

## Testing
- Not run (not requested).