### PR TITLE
fix: preserve model and reasoning across sessions

### DIFF
--- a/crates/threadlane-gpui/src/screens/workspace/view.rs
+++ b/crates/threadlane-gpui/src/screens/workspace/view.rs
@@ -256,6 +256,7 @@ impl WorkspaceView {
                             .or_insert(runtime);
                         state.is_generating = runtime.is_generating();
                         state.selected_model = runtime.selected_model.clone();
+                        state.reasoning_effort = runtime.reasoning_effort();
                         if let Some(status) = runtime_status_text(runtime.status()) {
                             state.session_status = Some(status);
                         }

--- a/crates/threadlane-gpui/src/state/app_state.rs
+++ b/crates/threadlane-gpui/src/state/app_state.rs
@@ -505,11 +505,35 @@ impl AppState {
     }
 
     pub(crate) fn set_reasoning_effort(&mut self, effort: ReasoningEffort) {
-        self.reasoning_effort = threadlane_runtime::model_registry::effective_effort(
+        let effort = threadlane_runtime::model_registry::effective_effort(
             &self.selected_model,
             effort,
             self.active_work_dir.as_deref(),
         );
+        if let Some((runtime, _)) = self.active_session_runtime() {
+            if runtime.is_generating() {
+                self.session_status =
+                    Some("Stop the current turn before changing reasoning effort".into());
+                return;
+            }
+            let result = if let Some(error) = runtime.harness_error() {
+                Err(error.to_string())
+            } else if let Ok(mut agent) = runtime.agent.try_lock() {
+                agent.set_fact("reasoning_effort", effort.label())
+            } else {
+                Err("Agent settings are still loading. Try changing reasoning effort again shortly."
+                    .into())
+            };
+            if let Err(error) = result {
+                self.session_status = Some(format!("Could not switch reasoning effort: {error}"));
+                return;
+            }
+            self.session_runtimes.remove(&runtime.session_file);
+        } else if self.reasoning_effort == effort {
+            return;
+        }
+        self.reasoning_effort = effort;
+        self.active_session_runtime();
     }
 
     pub(crate) fn open_settings(&mut self) {

--- a/crates/threadlane-gpui/src/state/app_state.rs
+++ b/crates/threadlane-gpui/src/state/app_state.rs
@@ -1219,6 +1219,7 @@ impl AppState {
             }
         } else {
             let model = runtime.model().to_owned();
+            let reasoning_effort = runtime.reasoning_effort();
             let (api_key, _) = provider_credentials(&model);
             if api_key.is_empty() && !threadlane_session::is_acp_model(&model) {
                 return None;
@@ -1232,7 +1233,7 @@ impl AppState {
                 session_id.clone(),
                 prompt.clone(),
                 Vec::new(),
-                self.reasoning_effort,
+                reasoning_effort,
                 self.stream_tx.clone(),
                 pending_acp,
             )
@@ -1467,6 +1468,15 @@ impl AppState {
                 }
             }
         }
+
+        threadlane_session::coding_agent::harness::CodingSessionHarness::append_fact_to_path(
+            &session_file,
+            "main",
+            "reasoning_effort",
+            self.reasoning_effort.label(),
+            None,
+        )
+        .map_err(|error| format!("failed to persist reasoning effort: {error}"))?;
 
         if let Some(project) = self
             .projects

--- a/crates/threadlane-gpui/src/state/tests.rs
+++ b/crates/threadlane-gpui/src/state/tests.rs
@@ -1164,6 +1164,24 @@ fn issue_work_state(work_dir: &Path) -> AppState {
 }
 
 #[test]
+fn new_session_persists_draft_reasoning_effort() {
+    let project = tempfile::tempdir().unwrap();
+    let mut state = issue_work_state(project.path());
+    state.reasoning_effort = ReasoningEffort::High;
+
+    let session_id = state.create_new_session().unwrap();
+    let session_file = project
+        .path()
+        .join(".threadlane/sessions")
+        .join(format!("{session_id}.jsonl"));
+
+    assert_eq!(
+        JsonlStore::open_read_only(session_file).unwrap().facts()["reasoning_effort"],
+        "High"
+    );
+}
+
+#[test]
 fn issue_work_session_persists_link_and_uses_isolated_worktree() {
     let repo = tempfile::tempdir().unwrap();
     run_git(repo.path(), &["init", "-b", "main"]);

--- a/crates/threadlane-gpui/src/state/tests.rs
+++ b/crates/threadlane-gpui/src/state/tests.rs
@@ -126,7 +126,7 @@ fn take_stream_events(state: &mut AppState, limit: usize) -> Vec<ChatStreamEvent
 }
 
 #[derive(Default)]
-struct ModelSelectionProvider(Mutex<Vec<String>>);
+struct ModelSelectionProvider(Mutex<Vec<(String, Option<String>)>>);
 
 #[async_trait::async_trait]
 impl threadlane_protocol::ProviderPort for ModelSelectionProvider {
@@ -135,7 +135,10 @@ impl threadlane_protocol::ProviderPort for ModelSelectionProvider {
         request: threadlane_protocol::RuntimeRequest,
         events: tokio::sync::mpsc::Sender<threadlane_protocol::RuntimeStreamEvent>,
     ) {
-        self.0.lock().unwrap().push(request.model);
+        self.0
+            .lock()
+            .unwrap()
+            .push((request.model, request.reasoning_effort));
         events
             .send(threadlane_protocol::RuntimeStreamEvent::ContentToken(
                 "done".into(),
@@ -169,7 +172,7 @@ impl threadlane_protocol::ProviderPort for ModelSelectionProvider {
 }
 
 #[tokio::test]
-async fn model_picker_persists_before_rebuild_and_next_provider_request() {
+async fn model_and_reasoning_pickers_persist_before_rebuild_and_next_request() {
     let selected = "opencode-go/minimax-m2.7";
     for has_runtime in [false, true] {
         let temp = tempfile::tempdir().unwrap();
@@ -203,12 +206,21 @@ async fn model_picker_persists_before_rebuild_and_next_provider_request() {
         }
 
         state.set_selected_model(selected.into());
+        state.set_reasoning_effort(ReasoningEffort::High);
 
         assert_eq!(state.selected_model, selected);
         assert_eq!(state.session_runtimes[&session_file].model(), selected);
         assert_eq!(
+            state.session_runtimes[&session_file].reasoning_effort(),
+            ReasoningEffort::High
+        );
+        assert_eq!(
             JsonlStore::open_read_only(&session_file).unwrap().facts()["model"],
             selected
+        );
+        assert_eq!(
+            JsonlStore::open_read_only(&session_file).unwrap().facts()["reasoning_effort"],
+            "High"
         );
         drop(state);
 
@@ -221,7 +233,10 @@ async fn model_picker_persists_before_rebuild_and_next_provider_request() {
         );
         let result = restored.handle_input_with_images("continue", vec![]).await;
         assert!(result.is_none(), "generation failed: {result:?}");
-        assert_eq!(*provider.0.lock().unwrap(), [selected]);
+        assert_eq!(
+            *provider.0.lock().unwrap(),
+            [(selected.to_string(), Some("high".into()))]
+        );
         let store = JsonlStore::open_read_only(&session_file).unwrap();
         assert!(store.records().iter().any(|record| matches!(
             record,

--- a/crates/threadlane-session/src/coding_agent/runtime.rs
+++ b/crates/threadlane-session/src/coding_agent/runtime.rs
@@ -396,6 +396,7 @@ impl CodingAgent {
         }
 
         let mut effective_model = options.model.clone();
+        let mut effective_reasoning_effort = ReasoningEffort::default();
         let (mut harness, harness_journal_error) = match session_file.as_deref() {
             Some(path) => match super::harness::CodingSessionHarness::open(path) {
                 Ok(h) => (Some(h), None),
@@ -410,6 +411,14 @@ impl CodingAgent {
         if let Some(h) = harness.as_ref() {
             if let Some(model) = h.store.facts().get("model") {
                 effective_model = model.clone();
+            }
+            if let Some(effort) = h
+                .store
+                .facts()
+                .get("reasoning_effort")
+                .and_then(|effort| ReasoningEffort::from_label(effort))
+            {
+                effective_reasoning_effort = effort;
             }
             if let Some(plan_json) = h.store.facts().get("session_plan") {
                 if let Ok(plan) = serde_json::from_str::<threadlane_runtime::SessionPlan>(plan_json)
@@ -458,6 +467,11 @@ impl CodingAgent {
                 panic!("Failed to create agent runtime: {error}");
             })
         };
+        agent
+            .turn
+            .try_lock()
+            .expect("new agent turn must be unlocked")
+            .reasoning_effort = effective_reasoning_effort;
         agent.session_id = session_id.clone();
         let harness_run_id: Arc<std::sync::Mutex<Option<String>>> =
             Arc::new(std::sync::Mutex::new(None));

--- a/crates/threadlane-session/src/controller.rs
+++ b/crates/threadlane-session/src/controller.rs
@@ -12,7 +12,7 @@ use crate::coding_agent::{
 };
 use crate::permission::{PermissionDecision, PermissionHandle};
 use crate::question::QuestionHandle;
-use crate::ModelRoles;
+use crate::{ModelRoles, ReasoningEffort};
 
 /// Execution mode configured for a session.
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
@@ -46,6 +46,7 @@ pub struct SessionController {
     pub session_file: PathBuf,
     mode: ExecutionMode,
     pub selected_model: String,
+    pub reasoning_effort: ReasoningEffort,
     pub system_prompt: String,
     pub harness_error: Option<String>,
     is_generating: AtomicBool,
@@ -80,6 +81,7 @@ impl SessionController {
         };
 
         let selected_model = agent.model().to_string();
+        let reasoning_effort = agent.agent.reasoning_effort();
 
         Arc::new(Self {
             agent: Arc::new(tokio::sync::Mutex::new(agent)),
@@ -91,6 +93,7 @@ impl SessionController {
             session_file,
             mode,
             selected_model,
+            reasoning_effort,
             system_prompt,
             harness_error,
             is_generating: AtomicBool::new(false),
@@ -109,6 +112,10 @@ impl SessionController {
 
     pub fn model(&self) -> &str {
         &self.selected_model
+    }
+
+    pub fn reasoning_effort(&self) -> ReasoningEffort {
+        self.reasoning_effort
     }
 
     pub fn system_prompt(&self) -> &str {


### PR DESCRIPTION
Closes #165

## Summary
- persist reasoning effort in the existing session fact store
- restore it when rebuilding a session runtime
- synchronize both model and effort when session hydration completes
- extend the provider-request regression test to cover both settings

## Validation
- `cargo check -p threadlane-gpui`
- `git diff --check`
- focused test build attempted three times (including `-j 1`), but the local rustc process crashed with `SIGBUS` while parsing before tests ran