### PR TITLE
Discover models and reasoning modes dynamically

### DIFF
--- a/crates/threadlane-gpui/src/model_catalog.rs
+++ b/crates/threadlane-gpui/src/model_catalog.rs
@@ -190,7 +190,11 @@ fn merge_discovered_opencode_models(models: &mut Vec<ModelOption>) {
 /// ids appear with generated labels. The last successful live result remains
 /// available if a later refresh fails.
 static DISCOVERED_OPENAI: std::sync::OnceLock<
-    std::sync::Mutex<(std::time::Instant, Vec<ModelOption>)>,
+    std::sync::Mutex<(
+        std::time::Instant,
+        Vec<ModelOption>,
+        Vec<threadlane_runtime::model_registry::ModelInfo>,
+    )>,
 > = std::sync::OnceLock::new();
 
 /// Pulls the live OpenAI model list and caches it for the picker. Skips the
@@ -214,9 +218,20 @@ pub async fn refresh_openai_models() {
     if api_key.trim().is_empty() {
         return;
     }
-    let mut discovered: Vec<ModelOption> =
-        threadlane_provider::openai::fetch_available_models(&api_key, account_id.as_deref())
-            .await
+    let general =
+        threadlane_provider::openai::try_fetch_available_models(&api_key, account_id.as_deref())
+            .await;
+    let subscription = threadlane_provider::openai::try_fetch_subscription_models().await;
+    if general.is_none() && subscription.is_none() {
+        return;
+    }
+    let cache = DISCOVERED_OPENAI
+        .get_or_init(|| std::sync::Mutex::new((std::time::Instant::now(), Vec::new(), Vec::new())));
+    let Ok(mut guard) = cache.lock() else {
+        return;
+    };
+    if let Some(general) = general {
+        guard.1 = general
             .into_iter()
             .map(|bare_id| ModelOption {
                 id: bare_id.clone(),
@@ -224,29 +239,15 @@ pub async fn refresh_openai_models() {
                 provider: ModelProvider::OpenAi,
             })
             .collect();
-    let subscription = threadlane_provider::openai::fetch_subscription_models().await;
-    for info in &subscription {
-        discovered.retain(|model| model.id != info.id);
-        discovered.push(ModelOption {
-            id: info.id.clone(),
-            label: info.label.clone(),
-            provider: ModelProvider::OpenAi,
-        });
     }
-    threadlane_runtime::model_registry::update_discovered_models(subscription);
-    discovered.sort_by(|a, b| a.id.cmp(&b.id));
-    if discovered.is_empty() {
-        return;
+    if let Some(subscription) = subscription {
+        threadlane_runtime::model_registry::update_discovered_models(
+            "openai",
+            subscription.clone(),
+        );
+        guard.2 = subscription;
     }
-    if let Some(cache) = DISCOVERED_OPENAI
-        .get_or_init(|| std::sync::Mutex::new((std::time::Instant::now(), Vec::new())))
-        .lock()
-        .ok()
-    {
-        let mut guard = cache;
-        guard.0 = std::time::Instant::now();
-        guard.1 = discovered;
-    }
+    guard.0 = std::time::Instant::now();
 }
 
 /// Refreshes the live OpenAI list, then rebuilds the picker's model list.
@@ -267,11 +268,22 @@ fn merge_discovered_openai_models(models: &mut Vec<ModelOption>) {
     if !credentials_allow(ModelProvider::OpenAi) {
         return;
     }
-    let discovered = DISCOVERED_OPENAI
+    let Some((mut discovered, subscription)) = DISCOVERED_OPENAI
         .get()
         .and_then(|cache| cache.lock().ok())
-        .map(|guard| guard.1.clone())
-        .unwrap_or_default();
+        .map(|guard| (guard.1.clone(), guard.2.clone()))
+    else {
+        return;
+    };
+    for info in subscription {
+        discovered.retain(|model| model.id != info.id);
+        discovered.push(ModelOption {
+            id: info.id,
+            label: info.label,
+            provider: ModelProvider::OpenAi,
+        });
+    }
+    discovered.sort_by(|a, b| a.id.cmp(&b.id));
     for option in discovered {
         if !models.iter().any(|model| model.id == option.id) {
             models.push(option);
@@ -319,9 +331,10 @@ pub async fn refresh_antigravity_models() {
             }),
     );
     synthesize_live_antigravity_models(&mut models, &ids);
-    threadlane_runtime::model_registry::update_discovered_models(antigravity_capabilities(
-        &models, &live,
-    ));
+    threadlane_runtime::model_registry::update_discovered_models(
+        "antigravity",
+        antigravity_capabilities(&models, &live),
+    );
     if let Some(cache) = DISCOVERED_ANTIGRAVITY
         .get_or_init(|| std::sync::Mutex::new((std::time::Instant::now(), None)))
         .lock()
@@ -410,7 +423,7 @@ fn synthesize_live_antigravity_models(models: &mut Vec<ModelOption>, available: 
     });
     for runtime_id in runtime_ids {
         if models.iter().any(|model| {
-            threadlane_runtime::ReasoningEffort::known_levels()
+            threadlane_runtime::model_registry::supported_efforts_for(&model.id, None)
                 .iter()
                 .any(|effort| {
                     threadlane_provider::antigravity::runtime_model_for(
@@ -421,7 +434,10 @@ fn synthesize_live_antigravity_models(models: &mut Vec<ModelOption>, available: 
         }) {
             continue;
         }
-        let base = runtime_id.strip_suffix("-tiered").unwrap_or(runtime_id);
+        let base = ["-tiered", "-low", "-medium", "-high"]
+            .into_iter()
+            .find_map(|suffix| runtime_id.strip_suffix(suffix))
+            .unwrap_or(runtime_id);
         let logical_id = format!("antigravity/{base}");
         if models.iter().any(|model| model.id == logical_id) {
             continue;
@@ -845,7 +861,10 @@ mod tests {
         let metadata = antigravity_capabilities(&models, &live);
         assert_eq!(metadata[0].supported_efforts, ["medium"]);
         assert_eq!(metadata[1].supported_efforts, ["off"]);
-        threadlane_runtime::model_registry::update_discovered_models(vec![metadata[1].clone()]);
+        threadlane_runtime::model_registry::update_discovered_models(
+            "antigravity",
+            vec![metadata[1].clone()],
+        );
         assert!(!supports_reasoning("antigravity/test-no-thinking", None));
     }
 

--- a/crates/threadlane-gpui/src/screens/settings/view.rs
+++ b/crates/threadlane-gpui/src/screens/settings/view.rs
@@ -639,9 +639,13 @@ impl SettingsView {
         let preferences = crate::services::subagent_settings::load(&project);
         let available = crate::model_catalog::available_models_for_project(Some(&project));
         let selected_model = preferences.model.clone();
+        let reasoning_model = selected_model
+            .as_deref()
+            .or(preferences.fast_model.as_deref())
+            .unwrap_or(&state.selected_model);
         let selected_reasoning = preferences.reasoning_effort.map(|effort| {
             threadlane_runtime::model_registry::effective_effort(
-                selected_model.as_deref().unwrap_or_default(),
+                reasoning_model,
                 effort,
                 Some(&project),
             )
@@ -657,7 +661,7 @@ impl SettingsView {
         let available_for_fast = available.clone();
         let model_entity = self.model.clone();
         let project_for_models = project.clone();
-        let reasoning_for_model = selected_model.clone().unwrap_or_default();
+        let reasoning_for_model = reasoning_model.to_string();
         // Reasoning controls hide for models without thinking (ACP agents,
         // off-only registry entries) instead of offering dead options. An
         // unset model inherits the parent, so the control stays visible.

--- a/crates/threadlane-gpui/src/state/app_state.rs
+++ b/crates/threadlane-gpui/src/state/app_state.rs
@@ -344,6 +344,13 @@ impl AppState {
     pub(crate) fn refresh_available_models(&mut self) {
         self.available_models =
             crate::model_catalog::available_models_for_project(self.active_work_dir.as_deref());
+        if self.selected_model.is_empty() {
+            self.selected_model = self
+                .available_models
+                .first()
+                .map(|model| model.id.clone())
+                .unwrap_or_default();
+        }
         self.set_reasoning_effort(self.reasoning_effort);
     }
 

--- a/crates/threadlane-provider/src/antigravity.rs
+++ b/crates/threadlane-provider/src/antigravity.rs
@@ -656,6 +656,9 @@ fn parse_available_models(value: &Value) -> Vec<AntigravityModelInfo> {
         .iter()
         .filter(|(_, info)| info.is_object())
         .filter(|(id, info)| {
+            if info.get("isInternal").and_then(Value::as_bool) == Some(true) {
+                return false;
+            }
             if let Some(sorts) = value.get("agentModelSorts").and_then(Value::as_array) {
                 id.ends_with("-tiered")
                     || sorts
@@ -772,6 +775,14 @@ fn resolve_runtime_model(model_id: &str, effort: &str) -> String {
     let model = model_id.strip_prefix("antigravity/").unwrap_or(model_id);
     if let Some(mapped) = runtime_model_override(model, effort) {
         return mapped;
+    }
+    let variant = format!("{model}-{effort}");
+    if LIVE_MODELS
+        .get()
+        .and_then(|models| models.read().ok())
+        .is_some_and(|models| models.iter().any(|entry| entry.id == variant))
+    {
+        return variant;
     }
     match model {
         "gemini-3.6-flash" => match effort {
@@ -1646,7 +1657,7 @@ mod tests {
     #[test]
     fn inventory_keeps_agent_capabilities_and_excludes_auxiliary_models() {
         let entries = parse_available_models(&json!({
-            "agentModelSorts": [{"groups": [{"modelIds": ["fast", "fixed", "variant"]}]}],
+            "agentModelSorts": [{"groups": [{"modelIds": ["fast", "fixed", "variant", "internal"]}]}],
             "models": {
                 "fast": {"supportsThinking": false},
                 "fixed": {"supportsThinking": true, "thinkingBudget": 1024},

--- a/crates/threadlane-provider/src/openai.rs
+++ b/crates/threadlane-provider/src/openai.rs
@@ -622,7 +622,7 @@ async fn fetch_available_models_network(
     account_id: Option<&str>,
     cache_key: u64,
     now: Instant,
-) -> Vec<String> {
+) -> Option<Vec<String>> {
     let cache = MODEL_CACHE.get_or_init(|| StdMutex::new(HashMap::new()));
     let mut req = http_client()
         .get("https://api.openai.com/v1/models")
@@ -641,27 +641,34 @@ async fn fetch_available_models_network(
                         .filter(|id| is_chat_capable_model(id))
                         .map(str::to_string)
                         .collect();
-                    if !models.is_empty() {
-                        models.sort();
-                        if let Ok(mut cache) = cache.lock() {
-                            cache.insert(
-                                cache_key,
-                                ModelCacheEntry {
-                                    stored_at: now,
-                                    models: models.clone().into(),
-                                },
-                            );
-                        }
-                        return models;
+                    models.sort();
+                    if let Ok(mut cache) = cache.lock() {
+                        cache.insert(
+                            cache_key,
+                            ModelCacheEntry {
+                                stored_at: now,
+                                models: models.clone().into(),
+                            },
+                        );
                     }
+                    return Some(models);
                 }
             }
         }
     }
-    Vec::new()
+    None
 }
 
 pub async fn fetch_available_models(api_key: &str, account_id: Option<&str>) -> Vec<String> {
+    try_fetch_available_models(api_key, account_id)
+        .await
+        .unwrap_or_default()
+}
+
+pub async fn try_fetch_available_models(
+    api_key: &str,
+    account_id: Option<&str>,
+) -> Option<Vec<String>> {
     let cache_key = model_cache_key(api_key, account_id);
     let now = Instant::now();
     let cache = MODEL_CACHE.get_or_init(|| StdMutex::new(HashMap::new()));
@@ -670,7 +677,7 @@ pub async fn fetch_available_models(api_key: &str, account_id: Option<&str>) -> 
             .get(&cache_key)
             .and_then(|entry| fresh_models(entry, now))
     }) {
-        return models.iter().cloned().collect();
+        return Some(models.iter().cloned().collect());
     }
     if tokio::runtime::Handle::try_current().is_ok() {
         fetch_available_models_network(api_key, account_id, cache_key, now).await
@@ -680,15 +687,17 @@ pub async fn fetch_available_models(api_key: &str, account_id: Option<&str>) -> 
         let handle = threadlane_runtime::get_runtime().spawn(async move {
             fetch_available_models_network(&api_key, account_id.as_deref(), cache_key, now).await
         });
-        match handle.await {
-            Ok(models) => models,
-            Err(_) => Vec::new(),
-        }
+        handle.await.ok().flatten()
     }
 }
 
 /// Codex model inventory and capabilities, not the general ChatGPT web picker.
 pub async fn fetch_subscription_models() -> Vec<threadlane_runtime::model_registry::ModelInfo> {
+    try_fetch_subscription_models().await.unwrap_or_default()
+}
+
+pub async fn try_fetch_subscription_models(
+) -> Option<Vec<threadlane_runtime::model_registry::ModelInfo>> {
     if tokio::runtime::Handle::try_current().is_ok() {
         fetch_subscription_models_inner().await
     } else {
@@ -698,7 +707,7 @@ pub async fn fetch_subscription_models() -> Vec<threadlane_runtime::model_regist
             .await
         {
             Ok(models) => models,
-            Err(_) => Vec::new(),
+            Err(_) => None,
         }
     }
 }
@@ -751,11 +760,12 @@ fn parse_subscription_models(value: &Value) -> Vec<threadlane_runtime::model_reg
         .collect()
 }
 
-async fn fetch_subscription_models_inner() -> Vec<threadlane_runtime::model_registry::ModelInfo> {
+async fn fetch_subscription_models_inner(
+) -> Option<Vec<threadlane_runtime::model_registry::ModelInfo>> {
     let credentials = threadlane_auth::openai_auth::load_credentials()
         .filter(|credentials| threadlane_auth::openai_auth::is_own_source(&credentials.source));
     let Some(credentials) = credentials else {
-        return Vec::new();
+        return None;
     };
     // Catalog visibility is gated by Codex client compatibility, not Threadlane's version.
     let client_version = std::env::var("CODEX_CLIENT_VERSION").unwrap_or_else(|_| "0.154.0".into());
@@ -775,15 +785,15 @@ async fn fetch_subscription_models_inner() -> Vec<threadlane_runtime::model_regi
     }
     let response = request.send().await;
     let Ok(response) = response else {
-        return Vec::new();
+        return None;
     };
     if !response.status().is_success() {
-        return Vec::new();
+        return None;
     }
     let Ok(value) = response.json::<Value>().await else {
-        return Vec::new();
+        return None;
     };
-    parse_subscription_models(&value)
+    Some(parse_subscription_models(&value))
 }
 
 #[derive(Clone, Debug, Default)]

--- a/crates/threadlane-runtime/src/model_registry.rs
+++ b/crates/threadlane-runtime/src/model_registry.rs
@@ -9,8 +9,12 @@ static DISCOVERED_MODELS: std::sync::OnceLock<std::sync::RwLock<HashMap<String, 
 
 /// Publish successful provider discovery for both selectors and request adapters.
 /// Failed/empty refreshes leave the last known capabilities intact.
-pub fn update_discovered_models(models: Vec<ModelInfo>) {
+pub fn update_discovered_models(provider: &str, models: Vec<ModelInfo>) {
+    if models.is_empty() {
+        return;
+    }
     if let Ok(mut cache) = DISCOVERED_MODELS.get_or_init(Default::default).write() {
+        cache.retain(|_, model| model.provider.as_deref() != Some(provider));
         for model in models {
             cache.insert(model.id.clone(), model);
         }
@@ -251,10 +255,14 @@ pub fn effective_effort(
 }
 
 /// `none` is an explicit provider mode; `off` means omit the parameter entirely.
-pub fn effective_api_effort(model_id: &str, effort: ReasoningEffort) -> Option<&'static str> {
-    let effective = effective_effort(model_id, effort, None);
+pub fn effective_api_effort(
+    model_id: &str,
+    effort: ReasoningEffort,
+    project_root: Option<&Path>,
+) -> Option<&'static str> {
+    let effective = effective_effort(model_id, effort, project_root);
     if effective == ReasoningEffort::Off
-        && find_model(model_id, None)
+        && find_model(model_id, project_root)
             .is_some_and(|model| model.supported_efforts.iter().any(|level| level == "none"))
     {
         Some("none")
@@ -321,6 +329,25 @@ mod tests {
             default_effort: None,
         };
         assert_eq!(info.efforts(), vec![ReasoningEffort::Off]);
+    }
+
+    #[test]
+    fn discovered_refresh_replaces_only_its_provider() {
+        let model = |id: &str, provider: &str| ModelInfo {
+            id: id.into(),
+            label: id.into(),
+            provider: Some(provider.into()),
+            context_window: None,
+            supported_efforts: vec!["low".into()],
+            default_effort: None,
+        };
+        update_discovered_models("replace-test", vec![model("retired", "replace-test")]);
+        update_discovered_models("other-test", vec![model("kept", "other-test")]);
+        update_discovered_models("replace-test", vec![model("current", "replace-test")]);
+
+        assert!(find_model("retired", None).is_none());
+        assert!(find_model("current", None).is_some());
+        assert!(find_model("kept", None).is_some());
     }
 
     #[test]

--- a/crates/threadlane-runtime/src/provider.rs
+++ b/crates/threadlane-runtime/src/provider.rs
@@ -97,7 +97,11 @@ impl ProviderAdapter for ChatCompletionsAdapter {
             chat_payload["prompt_cache_key"] = key.into();
         }
         if let Some(effort) =
-            crate::model_registry::effective_api_effort(&state.model, state.reasoning_effort)
+            crate::model_registry::effective_api_effort(
+                &state.model,
+                state.reasoning_effort,
+                state.project_root.as_deref(),
+            )
         {
             chat_payload["reasoning_effort"] = effort.into();
         }
@@ -149,7 +153,11 @@ impl ProviderAdapter for CodexResponsesAdapter {
             codex_payload["prompt_cache_key"] = key.into();
         }
         if let Some(effort) =
-            crate::model_registry::effective_api_effort(&state.model, state.reasoning_effort)
+            crate::model_registry::effective_api_effort(
+                &state.model,
+                state.reasoning_effort,
+                state.project_root.as_deref(),
+            )
         {
             codex_payload["reasoning"] = serde_json::json!({
                 "effort": effort,
@@ -705,6 +713,7 @@ mod tests {
             messages: Vec::new(),
             model: "test-reasoning-model".into(),
             reasoning_effort: ReasoningEffort::High,
+            project_root: None,
         };
         let payload = adapter.build_payload(&state, &[], None);
         assert_eq!(payload["model"], "test-reasoning-model");
@@ -720,6 +729,7 @@ mod tests {
             messages: Vec::new(),
             model: "gpt-5.6-luna".into(),
             reasoning_effort: ReasoningEffort::Low,
+            project_root: None,
         };
         let payload = adapter.build_payload(&state, &[], None);
         assert_eq!(payload["model"], "gpt-5.6-luna");
@@ -744,14 +754,15 @@ mod tests {
             messages: vec![],
             model: id.into(),
             reasoning_effort: ReasoningEffort::High,
+            project_root: None,
         };
-        update_discovered_models(vec![info.clone()]);
+        update_discovered_models("test", vec![info.clone()]);
         assert_eq!(
             ChatCompletionsAdapter.build_payload(&state, &[], None)["reasoning_effort"],
             "low"
         );
         info.supported_efforts = vec!["off".into()];
-        update_discovered_models(vec![info.clone()]);
+        update_discovered_models("test", vec![info.clone()]);
         assert!(
             ChatCompletionsAdapter
                 .build_payload(&state, &[], None)
@@ -765,10 +776,35 @@ mod tests {
                 .is_none()
         );
         info.supported_efforts = vec!["none".into()];
-        update_discovered_models(vec![info]);
+        update_discovered_models("test", vec![info]);
         assert_eq!(
             CodexResponsesAdapter.build_payload(&state, &[], None)["reasoning"]["effort"],
             "none"
+        );
+    }
+
+    #[test]
+    fn adapter_uses_project_reasoning_capabilities() {
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::create_dir(dir.path().join(".threadlane")).unwrap();
+        std::fs::write(
+            dir.path().join(".threadlane/models.json"),
+            r#"[{"id":"project-model","label":"Project","supported_efforts":["off"]}]"#,
+        )
+        .unwrap();
+        let state = TurnState {
+            system_prompt: String::new(),
+            messages: vec![],
+            model: "project-model".into(),
+            reasoning_effort: ReasoningEffort::High,
+            project_root: Some(dir.path().into()),
+        };
+
+        assert!(
+            ChatCompletionsAdapter
+                .build_payload(&state, &[], None)
+                .get("reasoning_effort")
+                .is_none()
         );
     }
 
@@ -780,6 +816,7 @@ mod tests {
             messages: Vec::new(),
             model: "test-model".into(),
             reasoning_effort: ReasoningEffort::default(),
+            project_root: None,
         };
 
         let chat = router.build_payload(PayloadFormat::ChatCompletions, &state, &[], None);
@@ -813,6 +850,7 @@ mod tests {
             ],
             model: "test-model".into(),
             reasoning_effort: ReasoningEffort::default(),
+            project_root: None,
         };
 
         let codex = router.build_payload(PayloadFormat::Codex, &state, &[], None);
@@ -834,6 +872,7 @@ mod tests {
             }],
             model: "test-model".into(),
             reasoning_effort: ReasoningEffort::default(),
+            project_root: None,
         };
 
         let codex = router.build_payload(PayloadFormat::Codex, &state, &[], None);

--- a/crates/threadlane-runtime/src/runtime.rs
+++ b/crates/threadlane-runtime/src/runtime.rs
@@ -121,6 +121,7 @@ impl AgentRuntime {
             messages: Vec::new(),
             model,
             reasoning_effort: Default::default(),
+            project_root: None,
         }));
 
         Self {

--- a/crates/threadlane-runtime/src/types.rs
+++ b/crates/threadlane-runtime/src/types.rs
@@ -536,6 +536,7 @@ pub struct TurnState {
     pub messages: Vec<AgentMessage>,
     pub model: String,
     pub reasoning_effort: ReasoningEffort,
+    pub project_root: Option<std::path::PathBuf>,
 }
 
 impl TurnState {

--- a/crates/threadlane-session/src/coding_agent/runtime.rs
+++ b/crates/threadlane-session/src/coding_agent/runtime.rs
@@ -757,6 +757,8 @@ impl CodingAgent {
             manager_clone.discover_and_connect().await;
         });
         agent.work_dir = Some(options.work_dir.clone());
+        agent.turn.try_lock().expect("new runtime turn is unlocked").project_root =
+            Some(options.work_dir.clone());
 
         let mut system_prompt_config = options.system_prompt.clone();
         if initial_tool_policy == ToolPolicy::ReadOnly {

--- a/crates/threadlane-session/src/coding_agent/subagents.rs
+++ b/crates/threadlane-session/src/coding_agent/subagents.rs
@@ -1086,6 +1086,7 @@ pub(crate) async fn run_subagent_task(
             .map_err(|error| format!("Failed to load subagent lane context: {error}"))?;
     }
     agent.work_dir = Some(context.work_dir.clone());
+    agent.turn.lock().await.project_root = Some(context.work_dir.clone());
 
     let session_file_for_checkpoint = context.session_file.clone();
 


### PR DESCRIPTION
Supersedes #181 and addresses all review comments from CodeRabbit and Codex.\n\n- preserve independent OpenAI inventories across partial refresh failures\n- replace live capability snapshots per provider without evicting other providers\n- carry project-scoped model capabilities into provider payloads\n- normalize inherited settings and select a default after initial discovery\n- exclude internal Antigravity models and consolidate effort-suffixed variants\n- deduplicate custom Antigravity effort routes\n\nValidation:\n- cargo check -p threadlane-gpui\n- cargo test -p threadlane-runtime discovered_refresh_replaces_only_its_provider\n- cargo test -p threadlane-runtime adapter_uses_project_reasoning_capabilities\n- cargo test -p threadlane-provider inventory_keeps_agent_capabilities_and_excludes_auxiliary_models\n- git diff --check\n\nThe focused GPUI test binary was attempted twice, including with CARGO_BUILD_JOBS=1, but rustc was interrupted by SIGBUS on this host.